### PR TITLE
Set default ENTRYPOINT in python-runtime

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,2 +1,1 @@
 FROM google/python-runtime
-ENTRYPOINT ["/env/bin/python", "/app/main.py"]

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -8,3 +8,4 @@ ONBUILD ADD . /app
 
 EXPOSE 8080
 CMD []
+ENTRYPOINT ["/env/bin/python", "main.py"]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -9,7 +9,6 @@ It is based on [`google/python`](https://index.docker.io/u/google/python) base i
 - Create a Dockerfile in your python application directory with the following content:
 
         FROM google/python-runtime
-        ENTRYPOINT ['/env/bin/python', '/app/main.py']
 
 - Run the following command in your application directory:
 
@@ -24,7 +23,9 @@ It is based on [`google/python`](https://index.docker.io/u/google/python) base i
 
 The image assumes that your application:
 
-- has a [`requirements.txt`](https://pip.pypa.io/en/latest/user_guide.html#requirements-files) file to specify its dependencies.
+- has a [`requirements.txt`](https://pip.pypa.io/en/latest/user_guide.html#requirements-files) file to specify its dependencies
 - listens on port `8080`
+- either has a `main.py` script as entrypoint or defines `ENTRYPOINT ["/env/bin/python", "/app/some_other_file.py"]` in its `Dockerfile`
+
 
 When building your application docker image, dependencies of your application are automatically fetched in a virtualenv using `pip install`.


### PR DESCRIPTION
Set the `ENTRYPOINT` in python-runtime to run a default `/app/main.py` file. This behaviour can be changed by overriding `ENTRYPOINT` in the application `Dockerfile`.
