### PR TITLE
Make requirements.txt optional

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,10 +1,9 @@
 FROM google/python
 
 WORKDIR /app
-ONBUILD RUN virtualenv /env
-ONBUILD ADD requirements.txt /app/requirements.txt
-ONBUILD RUN /env/bin/pip install -r /app/requirements.txt
 ONBUILD ADD . /app
+ONBUILD RUN virtualenv /env
+ONBUILD RUN [ -f /app/requirements.txt ] && /env/bin/pip install -r /app/requirements.txt || true
 
 EXPOSE 8080
 CMD []

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -23,9 +23,8 @@ It is based on [`google/python`](https://index.docker.io/u/google/python) base i
 
 The image assumes that your application:
 
-- has a [`requirements.txt`](https://pip.pypa.io/en/latest/user_guide.html#requirements-files) file to specify its dependencies
 - listens on port `8080`
 - either has a `main.py` script as entrypoint or defines `ENTRYPOINT ["/env/bin/python", "/app/some_other_file.py"]` in its `Dockerfile`
 
 
-When building your application docker image, dependencies of your application are automatically fetched in a virtualenv using `pip install`.
+When building your application docker image, dependencies of your application are automatically fetched in a virtualenv using `pip install` if a [`requirements.txt`](https://pip.pypa.io/en/latest/user_guide.html#requirements-files) file is found.


### PR DESCRIPTION
Attempt to install dependencies using `pip install` when a `requirements.txt` file exists but avoid exiting on error if it doesn't. I don't know if there was a deliberate intention behind having `ONBUILD ADD . /app` left at the end, so maybe this PR breaks something I'm not aware of.
