### PR TITLE
Switch base image from base to debian8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The Google App Engine base image is debian (jessie) with ca-certificates
 # installed.
-FROM gcr.io/google_appengine/base
+FROM gcr.io/google_appengine/debian8
 
 ADD resources /resources
 ADD scripts /scripts


### PR DESCRIPTION
The newest debian images for jessie (gcr.io/google-appengine/debian8:latest) now has all the extra env variables and ca-certs that were in base.

cc @dlorenc 