### PR TITLE
Second version of switching things to cloud build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cloudbuild.yaml
+interpreters.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV PYTHONUNBUFFERED 1
 RUN pip install --upgrade pip virtualenv
 
 # Install the Google-built interpreters
-ADD python-interpreter-builder/output/interpreters.tar.gz /
+ADD interpreters.tar.gz /
 
 # Setup the app working directory
 RUN ln -s /home/vmagent/app /app

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,8 @@ tests:
 .PHONY: benchmarks
 benchmarks:
 	make -C tests benchmarks
+
+.PHONY: cloudbuild
+cloudbuild:
+	envsubst <cloudbuild.yaml.in > cloudbuild.yaml
+	gcloud alpha container builds create . --config=cloudbuild.yaml

--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -1,0 +1,9 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '--tag=interpreter', 'python-interpreter-builder']
+- name: interpreter
+  args: ['cp', '/interpreters.tar.gz', '/workspace/']
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '--tag=${IMAGE_NAME}', '.']
+images:
+  ['${IMAGE_NAME}']

--- a/python-interpreter-builder/Makefile
+++ b/python-interpreter-builder/Makefile
@@ -6,5 +6,5 @@ build:
 	-docker rm python-interpreter-builder
 	docker run --name python-interpreter-builder google/python-interpreter-builder /bin/bash
 	mkdir -p output
-	docker cp python-interpreter-builder:/interpreters.tar.gz output/interpreters.tar.gz
+	docker cp python-interpreter-builder:/interpreters.tar.gz ../interpreters.tar.gz
 	docker rm python-interpreter-builder


### PR DESCRIPTION
Ref #29 #35 
cc @duggelz 

This version is a lot simpler but it builds the interpreter each time and takes about 35 minutes to run.
