### PR TITLE
Update apt-packages.txt for GeoDjango

### DIFF
--- a/resources/apt-packages.txt
+++ b/resources/apt-packages.txt
@@ -36,3 +36,7 @@ libsasl2-2
 libsasl2-dev
 libsasl2-modules
 sasl2-bin
+# Needed for GeoDjango
+binutils
+libproj-dev
+gdal-bin


### PR DESCRIPTION
I think these should be included by default as GeoDjango being very much popular for GIS applications.

Reference:
[https://docs.djangoproject.com/en/dev/ref/contrib/gis/](https://docs.djangoproject.com/en/dev/ref/contrib/gis/)