### PR TITLE
Fix "docker tag" usage for Docker 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ export IMAGE_NAME
 .PHONY: local-image
 local-image: build-interpreters
 	docker build $(DOCKER_FLAGS) -t "$(IMAGE_NAME)" .
-	docker tag -f "$(IMAGE_NAME)" "google/python"
+	-docker rmi "google/python" 2>/dev/null
+	docker tag "$(IMAGE_NAME)" "google/python"
 
 .PHONY: build-interpreters
 build-interpreters:

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -11,6 +11,7 @@ make build
 
 if [ "${UPLOAD_TO_STAGING}" = "true" ]; then
   STAGING="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:staging"
-  docker tag -f "${IMAGE_NAME}" "${STAGING}"
+  docker rmi "${STAGING}" 2>/dev/null || true # Ignore if tag not present
+  docker tag "${IMAGE_NAME}" "${STAGING}"
   gcloud docker push "${STAGING}"
 fi


### PR DESCRIPTION
Docker 1.12 removed support for the "-f" flag to "docker tag".
Replace it with code that should work for at least Docker 1.09 and
above.