### PR TITLE
prevent container build from using cached images

### DIFF
--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -1,10 +1,10 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '--tag=interpreter', 'python-interpreter-builder']
+  args: ['build', '--tag=interpreter', '--no-cache', 'python-interpreter-builder']
 - name: interpreter
   args: ['cp', '/interpreters.tar.gz', '/workspace/']
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '--tag=${IMAGE_NAME}', '.']
+  args: ['build', '--tag=${IMAGE_NAME}', '--no-cache', '.']
 - name: gcr.io/gcp-runtimes/structure_test
   args: [
     '-i', '${IMAGE_NAME}',


### PR DESCRIPTION
this will ensure security updates are picked up in the cloud build.