### PR TITLE
Reorganize the Makefile and add documentation for building the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,53 +6,66 @@ ifndef IMAGE_NAME
 $(error IMAGE_NAME is not set; invoke make with something like IMAGE_NAME=google/python:2017-01-02_03_45)
 endif
 
-
-.PHONY: local-image
-local-image: build-interpreters
-	docker build $(DOCKER_FLAGS) -t "$(IMAGE_NAME)" .
-	-docker rmi "google/python" 2>/dev/null
-	docker tag "$(IMAGE_NAME)" "google/python"
-
-.PHONY: build-interpreters
-build-interpreters:
-	export DOCKER_FLAGS
-	make -C python-interpreter-builder build
+## Files that must be refreshed every build
 
 .PHONY: cloudbuild.yaml # Force reevaluation of env vars every time
 cloudbuild.yaml: cloudbuild.yaml.in
-	envsubst < cloudbuild.yaml.in > cloudbuild.yaml
+	envsubst < $< > $@
 
-.PHONY: cloudbuild
-cloudbuild: cloudbuild.yaml
-	gcloud alpha container builds create . --config=cloudbuild.yaml
 
-.PHONY: build
-# no structure tests since they are implicit in cloudbuild
-build: cloudbuild integration-tests
-
-.PHONY: build-local
-build-local: local-image structure-tests integration-tests
+.PHONY: tests/google-cloud-python/Dockerfile # Force reevaluation of env vars every time
+tests/google-cloud-python/Dockerfile: tests/google-cloud-python/Dockerfile.in
+	envsubst < $< > $@
 
 .PHONY: ext_run.sh # Force refetch every time
 ext_run.sh:
 	curl https://raw.githubusercontent.com/GoogleCloudPlatform/runtimes-common/master/structure_tests/ext_run.sh > ext_run.sh
 	chmod +x ext_run.sh
 
-.PHONY: structure-tests
-structure-tests: local-image ext_run.sh
+## Build using Google Container Builder service
+
+.PHONY: cloud-build
+cloud-build: cloudbuild.yaml tests/google-cloud-python/Dockerfile
+	gcloud alpha container builds create . --config=cloudbuild.yaml
+
+.PHONY: cloud-test
+# structure-tests and google-cloud-python-tests are implicit in cloud-build
+cloud-test: cloud-build integration-tests
+
+## Build using local Docker daemon
+
+.PHONY: local-build
+local-build: local-build-interpreters
+	docker build $(DOCKER_FLAGS) -t "$(IMAGE_NAME)" .
+
+.PHONY: local-build-interpreters
+local-build-interpreters:
+	export DOCKER_FLAGS
+	make -C python-interpreter-builder build
+
+.PHONY: local-test
+local-test: local-build local-structure-tests local-google-cloud-python-tests integration-tests
+
+.PHONY: local-structure-tests
+local-structure-tests: local-build ext_run.sh
 	make -C tests structure-tests
+
+# Unit tests for Google Cloud Client Library for Python
+.PHONY: local-google-cloud-python-tests
+local-google-cloud-python-tests: tests/google-cloud-python/Dockerfile
+	make -C tests google-cloud-python
+
+## Always local
+
+.PHONY: integration-tests
+integration-tests: google-cloud-python-system-tests benchmarks
+
+# System tests for Google Cloud Client Library for Python.
+# They require gcloud auth and network access.
+.PHONY: google-cloud-python-system-tests
+google-cloud-python-system-tests:
+	make -C system_tests
 
 .PHONY: benchmarks
 benchmarks:
 	make -C tests benchmarks
-
-.PHONY: google-cloud-python
-google-cloud-python:
-	make -C tests google-cloud-python
-
-.PHONY: google-cloud-system-tests
-google-cloud-system-tests:
-	make -C system_tests
-
-.PHONY: integration-tests
-tests: benchmarks google-cloud-system-tests google-cloud-python

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ ifndef IMAGE_NAME
 $(error IMAGE_NAME is not set; invoke make with something like IMAGE_NAME=google/python:2017-01-02_03_45)
 endif
 
+.PHONY: all
+all:
+	cloud-test
+
 ## Files that must be refreshed every build
 
 .PHONY: cloudbuild.yaml # Force reevaluation of env vars every time

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Google Cloud Platform - Python Runtime Docker Image
 
-This repository contains the source for the `gcr.io/google_appengine/python` [docker](https://docker.io) base image. This image can be used as the base image for running applications on [Google App Engine Flexible](https://cloud.google.com/appengine/docs/flexible/), [Google Container Engine](https://cloud.google.com/container-engine), or any other Docker host.
+This repository contains the source for the
+[`gcr.io/google-appengine/python`](https://gcr.io/google-appengine/python)
+[docker](https://docker.io) base image. This image can be used as the base image
+for running applications on
+[Google App Engine Flexible](https://cloud.google.com/appengine/docs/flexible/),
+[Google Container Engine](https://cloud.google.com/container-engine), or any
+other Docker host.
 
-This image is based on Debian Jessie and contains packages required to build most of the popular Python libraries. For more information about this runtime, see the [documentation](https://cloud.google.com/appengine/docs/flexible/python/runtime).
+This image is based on Debian Jessie and contains packages required to build
+most of the popular Python libraries. For more information about this runtime,
+see the
+[documentation](https://cloud.google.com/appengine/docs/flexible/python/runtime).
 
 ## App Engine
 
-When using App Engine Flexible, you can use the runtime without worrying about docker by specifying `runtime: python` in your `app.yaml`:
+When using App Engine Flexible, you can use the runtime without worrying about
+docker by specifying `runtime: python` in your `app.yaml`:
 
 ```yaml
 runtime: python
@@ -18,17 +28,23 @@ runtime_config:
   python_version: 3
 ```
 
-If you have an existing App Engine application using this runtime and want to customize it, you can use the [`Cloud SDK`](https://cloud.google.com/sdk/gcloud/reference/preview/app/gen-config) to create a custom runtime:
+If you have an existing App Engine application using this runtime and want to
+customize it, you can use the
+[`Cloud SDK`](https://cloud.google.com/sdk/gcloud/reference/preview/app/gen-config)
+to create a custom runtime:
 
     gcloud beta app gen-config --custom 
 
-You can then modify the `Dockerfile` and `.dockerignore` as needed for you application. 
+You can then modify the `Dockerfile` and `.dockerignore` as needed for you
+application.
 
 ## Container Engine & other Docker hosts.
   
-For other docker hosts, you'll need to create a `Dockerfile` based on this image that copies your application code, installs dependencies, and declares an command or entrypoint. For example:
+For other docker hosts, you'll need to create a `Dockerfile` based on this image
+that copies your application code, installs dependencies, and declares an
+command or entrypoint. For example:
 
-    FROM gcr.io/google_appengine/python
+    FROM gcr.io/google-appengine/python
     
     # Create a virtualenv for dependencies. This isolates these packages from
     # system-level packages.
@@ -50,6 +66,37 @@ For other docker hosts, you'll need to create a `Dockerfile` based on this image
     # Run a WSGI server to serve the application. gunicorn must be declared as
     # a dependency in requirements.txt.
     CMD gunicorn -b :$PORT main:app
+
+## Building the image
+
+Google regularly builds and releases this image at
+[`gcr.io/google-appengine/python`](https://gcr.io/google-appengine/python).
+
+To rebuild the image yourself, first set the following variables in your
+shell. You need to be authenticated to a Google Cloud Project to invoke the
+Google Container Builder service, and also to run the system tests.
+
+```shell
+$ export GCLOUD_PROJECT=YOUR-PROJECT-NAME
+$ DOCKER_NAMESPACE=gcr.io/${GCLOUD_PROJECT}
+$ CANDIDATE_NAME=`date +%Y-%m-%d_%H_%M`
+$ export IMAGE_NAME=${DOCKER_NAMESPACE}/python:${CANDIDATE_NAME}
+```
+
+To rebuild the image using the Google Container Builder service, do the
+following:
+
+```shell
+$ make cloud-build
+$ make cloud-test
+```
+
+To rebuild the image using your local Docker daemon, do the following:
+
+``` shell
+$ make local-build
+$ make local-test
+```
 
 ## Contributing changes
 

--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -18,5 +18,7 @@ steps:
     '--config', '/workspace/tests/license-test/license-test.yaml',
     '-v'
   ]
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '--tag=google-cloud-python-tests', '--no-cache', '/workspace/tests/google-cloud-python/']
 images:
   ['${IMAGE_NAME}']

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -7,8 +7,12 @@ RUNTIME_NAME="python"
 CANDIDATE_NAME=`date +%Y-%m-%d_%H_%M`
 echo "CANDIDATE_NAME:${CANDIDATE_NAME}"
 
+if [ -z "${DOCKER_NAMESPACE+set}" ] ; then
+  echo "Error: DOCKER_NAMESPACE is not set; invoke with something like DOCKER_NAMESPACE=gcr.io/YOUR-PROJECT-NAME" >&2
+  exit 1
+fi
 IMAGE_NAME="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
 
 export IMAGE_NAME
 export FORCE_REBUILD
-make build
+make cloud-test

--- a/system_tests/Makefile
+++ b/system_tests/Makefile
@@ -2,10 +2,10 @@
 # a `git clone` which can not be cached.
 DOCKER_FLAGS ?= --no-cache
 
+.PHONY: all
+all: Dockerfile
+	docker build $(DOCKER_FLAGS) .
+
 .PHONY:	Dockerfile
 Dockerfile: Dockerfile.in
 	envsubst < $< > $@
-
-.PHONY: all
-all:
-	docker build $(DOCKER_FLAGS) .

--- a/system_tests/Makefile
+++ b/system_tests/Makefile
@@ -1,8 +1,11 @@
 # Use no-cache to prevent layer caching because there is a layer that does
 # a `git clone` which can not be cached.
-CACHE ?= --no-cache
+DOCKER_FLAGS ?= --no-cache
+
+.PHONY:	Dockerfile
+Dockerfile: Dockerfile.in
+	envsubst < $< > $@
 
 .PHONY: all
 all:
-	envsubst < Dockerfile.in > Dockerfile
-	docker build $(CACHE) .
+	docker build $(DOCKER_FLAGS) .

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,6 @@
+.PHONY: all
+all: structure-tests benchmarks google-cloud-python
+
 .PHONY: structure-tests
 structure-tests:
 	make -C no-virtualenv

--- a/tests/google-cloud-python/Dockerfile.in
+++ b/tests/google-cloud-python/Dockerfile.in
@@ -14,5 +14,4 @@ RUN python2.7 scripts/run_unit_tests.py
 RUN python3.4 scripts/run_unit_tests.py
 
 # Run Python 3.5 unit tests
-ENV PATH /opt/python3.5/bin:$PATH
 RUN python3.5 scripts/run_unit_tests.py


### PR DESCRIPTION
All targets using the Google Container Builder are prefixed with 'cloud-' and all targets that use the local Docker daemon are prefixed with 'local-'.

The google-cloud-python system tests will be addressed in later change.