### PR TITLE
Remove 'distribute' from library test.

### DIFF
--- a/tests/python2-libraries/requirements.txt
+++ b/tests/python2-libraries/requirements.txt
@@ -35,7 +35,6 @@ cryptography==1.8.1
 cssselect==1.0.1
 cython==0.25.2
 decorator==4.0.11
-distribute==0.7.3
 django-celery==3.2.1
 django-debug-toolbar==1.7
 django-extensions==1.7.8


### PR DESCRIPTION
'pip install distribute' unpredictably fails when other packages are
being updated at the same time.  See
https://github.com/pypa/setuptools/issues/535 for related discussion.

Error message looks like:

  Running setup.py install for distribute: started
  Running setup.py install for distribute: finished with status 'error'
  Complete output from command /env/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-9DiKZ8/distribute/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-zFa039-record/install-record.txt --single-version-externally-managed --compile --install-headers /env/include/site/python2.7/distribute:
  running install
  running build
  running install_egg_info
  running egg_info
  writing requirements to distribute.egg-info/requires.txt
  writing distribute.egg-info/PKG-INFO
  writing top-level names to distribute.egg-info/top_level.txt
  writing dependency_links to distribute.egg-info/dependency_links.txt
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-9DiKZ8/distribute/setup.py", line 58, in <module>
      setuptools.setup(**setup_params)
    File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
      dist.run_commands()
    File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "setuptools/command/install.py", line 53, in run
      return _install.run(self)
    File "/usr/lib/python2.7/distutils/command/install.py", line 613, in run
      self.run_command(cmd_name)
    File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "setuptools/command/install_egg_info.py", line 29, in run
      self.run_command('egg_info')
    File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "setuptools/command/egg_info.py", line 177, in run
      writer = ep.load(installer=installer)
    File "pkg_resources.py", line 2241, in load
      if require: self.require(env, installer)
    File "pkg_resources.py", line 2254, in require
      working_set.resolve(self.dist.requires(self.extras),env,installer)))
    File "pkg_resources.py", line 2471, in requires
      dm = self._dep_map
    File "pkg_resources.py", line 2682, in _dep_map
      self.__dep_map = self._compute_dependencies()
    File "pkg_resources.py", line 2699, in _compute_dependencies
      from _markerlib import compile as compile_marker
  ImportError: No module named _markerlib