### PR TITLE
Change handling of GOOGLE_CLOUD_PROJECT in build.sh.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ specified, the current time will be used (timestamp format `YYYY-mm-dd-HHMMSS`).
 GOOGLE_APPLICATION_CREDENTIALS
 : (System test only) Path to service account credentials in JSON format.
 
-GOOGLE_CLOUD_PROJECT
+GOOGLE_CLOUD_PROJECT_FOR_TESTS
 : (System test only) Name of the Google Cloud Platform project to run the system
 tests under.
   

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ TAG
 : The suffix applied to all images created.  This should be unique.  If not
 specified, the current time will be used (timestamp format `YYYY-mm-dd-HHMMSS`).
 
-GOOGLE_APPLICATION_CREDENTIALS
+GOOGLE_APPLICATION_CREDENTIALS_FOR_TESTS
 : (System test only) Path to service account credentials in JSON format.
 
 GOOGLE_CLOUD_PROJECT_FOR_TESTS

--- a/build.sh
+++ b/build.sh
@@ -97,8 +97,8 @@ fi
 
 # Read action-specific environment variables
 if [ "${system_tests}" -eq 1 ]; then
-  if [ -z "${GOOGLE_APPLICATION_CREDENTIALS+set}" ] ; then
-    fatal 'Error: $GOOGLE_APPLICATION_CREDENTIALS is not set; invoke with something like GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/creds.json'
+  if [ -z "${GOOGLE_APPLICATION_CREDENTIALS_FOR_TESTS+set}" ] ; then
+    fatal 'Error: $GOOGLE_APPLICATION_CREDENTIALS_FOR_TESTS is not set; invoke with something like GOOGLE_APPLICATION_CREDENTIALS_FOR_TESTS=/path/to/service/account/creds.json'
   fi
 
   if [ -z "${GOOGLE_CLOUD_PROJECT_FOR_TESTS+set}" ] ; then
@@ -139,7 +139,7 @@ if [ "${system_tests}" -eq 1 ]; then
   echo "Running system tests using project ${GOOGLE_CLOUD_PROJECT_FOR_TESTS}"
 
   trap "rm -f tests/google-cloud-python-system/credentials.json" EXIT
-  cp "${GOOGLE_APPLICATION_CREDENTIALS}" tests/google-cloud-python-system/credentials.json
+  cp "${GOOGLE_APPLICATION_CREDENTIALS_FOR_TESTS}" tests/google-cloud-python-system/credentials.json
   ${gcloud_cmd} --config cloudbuild_system_tests.yaml --substitutions  "${substitutions}" || \
     exit_code=1
   rm -f tests/google-cloud-python-system/credentials.json

--- a/build.sh
+++ b/build.sh
@@ -101,8 +101,8 @@ if [ "${system_tests}" -eq 1 ]; then
     fatal 'Error: $GOOGLE_APPLICATION_CREDENTIALS is not set; invoke with something like GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/creds.json'
   fi
 
-  if [ -z "${GOOGLE_CLOUD_PROJECT+set}" ] ; then
-    fatal 'Error: $GOOGLE_CLOUD_PROJECT is not set; invoke with something like GOOGLE_CLOUD_PROJECT=YOUR-PROJECT-NAME'
+  if [ -z "${GOOGLE_CLOUD_PROJECT_FOR_TESTS+set}" ] ; then
+    fatal 'Error: $GOOGLE_CLOUD_PROJECT_FOR_TESTS is not set; invoke with something like GOOGLE_CLOUD_PROJECT_FOR_TESTS=YOUR-PROJECT-NAME'
   fi
 fi
 
@@ -120,7 +120,7 @@ for outfile in \
   tests/google-cloud-python-system/Dockerfile \
   tests/integration/Dockerfile \
   ; do
-  envsubst <"${outfile}".in >"${outfile}" '$DEBIAN_BASE_IMAGE $FULL_BASE_IMAGE $GOOGLE_CLOUD_PROJECT'
+  envsubst <"${outfile}".in >"${outfile}" '$DEBIAN_BASE_IMAGE $FULL_BASE_IMAGE $GOOGLE_CLOUD_PROJECT_FOR_TESTS'
 done
 
 # Build images and push to GCR
@@ -136,7 +136,7 @@ exit_code=0
 
 # Run system tests
 if [ "${system_tests}" -eq 1 ]; then
-  echo "Running system tests using project ${GOOGLE_CLOUD_PROJECT}"
+  echo "Running system tests using project ${GOOGLE_CLOUD_PROJECT_FOR_TESTS}"
 
   trap "rm -f tests/google-cloud-python-system/credentials.json" EXIT
   cp "${GOOGLE_APPLICATION_CREDENTIALS}" tests/google-cloud-python-system/credentials.json

--- a/tests/google-cloud-python-system/Dockerfile.in
+++ b/tests/google-cloud-python-system/Dockerfile.in
@@ -9,7 +9,7 @@ RUN pip install --upgrade nox-automation
 
 # Secrets injected at runtime
 ENV GOOGLE_APPLICATION_CREDENTIALS=/workspace/tests/google-cloud-python-system/credentials.json
-ENV GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}
+ENV GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT_FOR_TESTS}
 
 # Run system tests for all supported Python versions
 ADD run_system_tests.sh /run_system_tests.sh


### PR DESCRIPTION
The previous behavior could possibly, conceivably be causing problems.
Now, the user now specifies GOOGLE_CLOUD_PROJECT_FOR_TESTS, which
should not collide with anything, and the GOOGLE_CLOUD_PROJECT
environment variable is only set for the single thing that should need
it, which is run_system_tests.sh, and only in the single, ephemeral
Docker container where we run those system tests.