### PR TITLE
Updated the benchmark code to migrate to the new Python benchmark suite

### DIFF
--- a/tests/benchmark/Dockerfile.in
+++ b/tests/benchmark/Dockerfile.in
@@ -1,6 +1,19 @@
 FROM ${FULL_BASE_IMAGE}
 
-RUN hg clone -r 9923b81a1d34 https://hg.python.org/benchmarks /app/benchmarks
-WORKDIR /app/benchmarks
-RUN python perf.py -r -b default /usr/bin/python2.7 /usr/bin/python3.4
-RUN python perf.py -r -b default /usr/bin/python3.4 /opt/python3.5/bin/python3.5
+# Install performance
+RUN python2 -m pip install performance
+
+# Create virtual environment
+RUN pip install --upgrade virtualenv
+
+# Download ensurepip module which prevents the failure when benchmarking python3, can be removed once we drop debian's 3.4
+RUN wget https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz
+RUN tar xzf Python-3.4.2.tgz
+RUN cp -R Python-3.4.2/Lib/ensurepip /usr/lib/python3.4
+
+# Run the benchmark and compare the performance, add the --debug-single-value flag to let the benchmark run in fastest mode
+RUN pyperformance run --debug-single-value --python=python2.7 -o py2.7.json
+RUN pyperformance run --debug-single-value --python=python3.4 -o py3.4.json
+RUN pyperformance run --debug-single-value --python=python3.5 -o py3.5.json
+RUN pyperformance compare py2.7.json py3.4.json --output_style table
+RUN pyperformance compare py3.4.json py3.5.json --output_style table


### PR DESCRIPTION
The new benchmark suite runs experiment on 54 Python functions while the previous one runs on 10 functions. So it took much longer for the new benchmark to complete and sometimes causes time-out issue. To solve this, I added the --debug-single-value flag to the command which runs single experiment per function so the benchmark can complete faster. The only concern is that the result for comparison using single value is not stable, an alternative approach might be specifying which functions we want to do experiments on instead of on all of the 54 functions.

Tested on gcr.io/cloud-python-runtime-qa.

Command:
DOCKER_NAMESPACE=gcr.io/cloud-python-runtime-qa TAG=latest ./build.sh --nobuild --benchmark

Result (partial):
![screenshot from 2017-04-13 11 23 09](https://cloud.githubusercontent.com/assets/12888824/25018289/aee9a0d2-203b-11e7-8e03-c5d70ab3e12b.png)
