### PR TITLE
Benchmark the same interpreter from release to release.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,8 +72,16 @@ docker run -it --entrypoint /bin/bash YOUR-IMAGE-NAME
 There is a benchmark suite which compares the performance of interpreters
 against each other.
 
+**Benchmark different versions of interpreter in the same release
+
 ``` shell
-./build.sh --nobuild --benchmark
+DOCKER_NAMESPACE=DOCKER_NAMESPACE_EXAMPLE TAG=TAG_EXAMPLE ./build.sh --nobuild --benchmark
+```
+
+**Benchmark same versions of interpreter from release to release
+
+``` shell
+DOCKER_NAMESPACE=DOCKER_NAMESPACE_EXAMPLE TAG1=TAG1_EXAMPLE TAG2=TAG2_EXAMPLE ./benchmark_between_releases.sh
 ```
 
 Since these benchmarks are run on cloud instances, the timings may vary from run

--- a/tests/benchmark/Dockerfile.in
+++ b/tests/benchmark/Dockerfile.in
@@ -11,9 +11,11 @@ RUN wget https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz
 RUN tar xzf Python-3.4.2.tgz
 RUN cp -R Python-3.4.2/Lib/ensurepip /usr/lib/python3.4
 
+RUN mkdir /result
+
 # Run the benchmark and compare the performance, add the --debug-single-value flag to let the benchmark run in fastest mode
-RUN pyperformance run --debug-single-value --python=python2.7 -o py2.7.json
-RUN pyperformance run --debug-single-value --python=python3.4 -o py3.4.json
-RUN pyperformance run --debug-single-value --python=python3.5 -o py3.5.json
-RUN pyperformance compare py2.7.json py3.4.json --output_style table
-RUN pyperformance compare py3.4.json py3.5.json --output_style table
+RUN pyperformance run --debug-single-value --python=python2.7 -o /result/py2.7.json
+RUN pyperformance run --debug-single-value --python=python3.4 -o /result/py3.4.json
+RUN pyperformance run --debug-single-value --python=python3.5 -o /result/py3.5.json
+RUN pyperformance compare /result/py2.7.json /result/py3.4.json --output_style table
+RUN pyperformance compare /result/py3.4.json /result/py3.5.json --output_style table

--- a/tests/benchmark/benchmark_between_releases.sh
+++ b/tests/benchmark/benchmark_between_releases.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Build the benchmark image for release 1 from Dockerfile
+echo "Building image for release 1"
+export FULL_BASE_IMAGE="${DOCKER_NAMESPACE}/python:${TAG1}"
+envsubst <"Dockerfile".in >"Dockerfile" '$FULL_BASE_IMAGE'
+docker build --no-cache -t benchmark_1 .
+rm Dockerfile
+
+# Build the benchmark image for release 2 from Dockerfile
+echo "Building image for release 2"
+export FULL_BASE_IMAGE="${DOCKER_NAMESPACE}/python:${TAG2}"
+envsubst <"Dockerfile".in >"Dockerfile" '$FULL_BASE_IMAGE'
+docker build --no-cache -t benchmark_2 .
+rm Dockerfile
+
+echo "Successfully built images"
+
+# Create folders to hold the files
+mkdir release1
+mkdir release2
+
+# Start running the containers and copy the benchmark result for python versions from container to host
+docker run -it --name benchmark_1 -h CONTAINER1 -v "${PWD}"/release1:/export benchmark_1 /bin/bash -c "cp /result/py*.json /export/"
+docker run -it --name benchmark_2 -h CONTAINER2 -v "${PWD}"/release2:/export benchmark_2 /bin/bash -c "cp /result/py*.json /export/"
+
+echo "Start benchmarking the python interpreter performance between the two releases"
+
+# Compare the performance between the interpreter in different release
+pyperformance compare release1/py2.7.json release2/py2.7.json --output_style table > py2.7_res
+pyperformance compare release1/py3.4.json release2/py3.4.json --output_style table > py3.4_res
+pyperformance compare release1/py3.5.json release2/py3.5.json --output_style table > py3.5_res
+
+echo "Completed"


### PR DESCRIPTION
Added code to benchmark the same interpreter from release to release. The workflow is that first build image for release1 and release2, then do docker cp to get the benchmark json files from the image to host. And finally do pyperformance compare on the json files. Then the result of comparing python versions for the two releases are stored as files on host named as py2.7_res, py3.4_res and py3.5_res.

Test completed.

Command: DOCKER_NAMESPACE=gcr.io/google-appengine TAG1=2017-02-28_19_33 TAG2=2017-04-07-115536 ./benchmark_between_releases.sh

Usage: cd to tests/benchmark/benchmark_between_releases/ and run the shell script.