### PR TITLE
Remove unused files to make the Docker image smaller

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,6 +18,7 @@ steps:
     '--config', '/workspace/tests/virtualenv/virtualenv_default.yaml',
     '--config', '/workspace/tests/virtualenv/virtualenv_python34.yaml',
     '--config', '/workspace/tests/virtualenv/virtualenv_python35.yaml',
+    '--config', '/workspace/tests/virtualenv/virtualenv_python36.yaml',
     '--config', '/workspace/tests/no-virtualenv/no-virtualenv.yaml',
     '--config', '/workspace/tests/python2-libraries/python2-libraries.yaml',
     '--config', '/workspace/tests/python3-libraries/python3-libraries.yaml',

--- a/python-interpreter-builder/Dockerfile.in
+++ b/python-interpreter-builder/Dockerfile.in
@@ -36,8 +36,8 @@ RUN apt-get update && apt-get install -yq \
     wget \
     xauth \
     xvfb \
-    zlib1g-dev
-
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # Setup locale. This prevents Python 3 IO encoding issues.
 ENV LANG C.UTF-8

--- a/python-interpreter-builder/scripts/build-python-3.5.sh
+++ b/python-interpreter-builder/scripts/build-python-3.5.sh
@@ -87,6 +87,8 @@ QUILT_PATCHES=/patches/3.5 quilt push -a
 # Specifically EXTRA_CFLAGS="-g -flto -fuse-linker-plugin
 # -ffat-lto-objects"
 
+PREFIX=/opt/python3.5
+
 mkdir build-static
 cd build-static
 
@@ -94,7 +96,7 @@ cd build-static
   --enable-ipv6 \
   --enable-loadable-sqlite-extensions \
   --enable-optimizations \
-  --prefix=/opt/python3.5 \
+  --prefix="$PREFIX" \
   --with-dbmliborder=bdb:gdbm \
   --with-computed-gotos \
   --with-fpectl \
@@ -117,13 +119,32 @@ cd build-static
   RANLIB="x86_64-linux-gnu-gcc-ranlib" \
 
 make profile-opt
-make altinstall
 
 # Run tests
 # test___all__: Depends on Debian-specific locale changes
+# test_dbm: https://bugs.python.org/issue28700
 # test_imap: https://bugs.python.org/issue30175
 # test_shutil: https://bugs.python.org/issue29317
-make test TESTOPTS="--exclude test___all__ test_imaplib test_shutil"
+make test TESTOPTS="--exclude test___all__ test_dbm test_imaplib test_shutil"
+
+# Install
+make altinstall
+# We don't expect users to statically link Python into a C/C++ program
+rm "$PREFIX"/lib/libpython3.5m.a \
+  "$PREFIX"/lib/python3.5/config-*/libpython3.5m.a
+# Remove opt-mode bytecode
+find "$PREFIX"/lib/python3.5/ \
+  -name \*.opt-\?.pyc \
+  -exec rm {} \;
+# Remove all but a few files in the 'test' subdirectory
+find "$PREFIX"/lib/python3.5/test \
+  -mindepth 1 -maxdepth 1 \
+  \! -name support \
+  -a \! -name __init__.py \
+  -a \! -name pystone.\* \
+  -a \! -name regrtest.\* \
+  -a \! -name test_support.py \
+  -exec rm -rf {} \;
 
 # Clean-up sources
 cd /opt

--- a/tests/virtualenv/virtualenv_python34.yaml
+++ b/tests/virtualenv/virtualenv_python34.yaml
@@ -42,3 +42,6 @@ commandTests:
 
   - name: "flask integration"
     command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+
+  - name: "test.support"
+    command: ["python", "-c", "\"from test import pystone, regrtest, support\""]

--- a/tests/virtualenv/virtualenv_python35.yaml
+++ b/tests/virtualenv/virtualenv_python35.yaml
@@ -46,3 +46,6 @@ commandTests:
 
   - name: "flask integration"
     command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+
+  - name: "test.support"
+    command: ["python", "-c", "\"from test import pystone, regrtest, support\""]

--- a/tests/virtualenv/virtualenv_python36.yaml
+++ b/tests/virtualenv/virtualenv_python36.yaml
@@ -29,7 +29,7 @@ commandTests:
 
   - name: "python version"
     command: ["python", "--version"]
-    expectedOutput: ["Python 3.6.3\n"]
+    expectedOutput: ["Python 3.6.1\n"]
 
   - name: "pip installation"
     command: ["which", "pip"]
@@ -46,3 +46,6 @@ commandTests:
 
   - name: "flask integration"
     command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+
+  - name: "test.support"
+    command: ["python", "-c", "\"from test import pystone, regrtest, support\""]


### PR DESCRIPTION
Adding Python 3.6 made the image grow to more than 1GB.  This reduces the image back down to 770MB.