### PR TITLE
Replace deprecated "vm: true" in app.yaml example with "env: flex"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker by specifying `runtime: python` in your `app.yaml`:
 
 ```yaml
 runtime: python
-vm: true
+env: flex
 entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:


### PR DESCRIPTION
This brings it up to date with official documentation: https://cloud.google.com/appengine/docs/flexible/python/runtime