### PR TITLE
Rename builder image to parallel the other languages' builders.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,11 +50,19 @@ if [ -z "${DOCKER_NAMESPACE+set}" ] ; then
   fatal 'Error: $DOCKER_NAMESPACE is not set; invoke with something like DOCKER_NAMESPACE=gcr.io/YOUR-PROJECT-NAME'
 fi
 
+if [ -z "${BUILDER_DOCKER_NAMESPACE+set}" ] ; then
+  export BUILDER_DOCKER_NAMESPACE="${DOCKER_NAMESPACE}"
+fi
+
 if [ -z "${TAG+set}" ] ; then
   export TAG=`date +%Y-%m-%d-%H%M%S`
 fi
 
-substitutions="_DOCKER_NAMESPACE=${DOCKER_NAMESPACE},_TAG=${TAG}"
+substitutions="\
+_BUILDER_DOCKER_NAMESPACE=${BUILDER_DOCKER_NAMESPACE},\
+_DOCKER_NAMESPACE=${DOCKER_NAMESPACE},\
+_TAG=${TAG}\
+"
 
 # Read command line arguments
 while [ $# -gt 0 ]; do

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,9 +33,9 @@ steps:
   name: ${_DOCKER_NAMESPACE}/python/tests/google-cloud-python:${_TAG}
 - # Build runtime builder image
   name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=${_DOCKER_NAMESPACE}/python/builder/gen-dockerfile:${_TAG}',
+  args: ['build', '--tag=${_BUILDER_DOCKER_NAMESPACE}/python/gen-dockerfile:${_TAG}',
          '--no-cache', '/workspace/builder/gen-dockerfile/']
 images: [
   '${_DOCKER_NAMESPACE}/python:${_TAG}',
-  '${_DOCKER_NAMESPACE}/python/builder/gen-dockerfile:${_TAG}',
+  '${_BUILDER_DOCKER_NAMESPACE}/python/gen-dockerfile:${_TAG}',
 ]


### PR DESCRIPTION
The canonical builder image will be `gcr.io/gcp-runtimes/python/gen-dockerfile`