### PR TITLE
Allow $GAE_APPLICATION_YAML_PATH as an alternative to --config

### DIFF
--- a/scripts/gen_dockerfile.py
+++ b/scripts/gen_dockerfile.py
@@ -57,6 +57,8 @@ PYTHON_INTERPRETER_VERSION_MAP = {
     '3.6': '3.6',
 }
 
+# Name of environment variable potentially set by gcloud
+GAE_APPLICATION_YAML_PATH = 'GAE_APPLICATION_YAML_PATH'
 
 # Validated application configuration
 AppConfig = collections.namedtuple(
@@ -225,11 +227,19 @@ def parse_args(argv):
             validation_utils.validate_arg_regex, flag_regex=IMAGE_REGEX),
         default='gcr.io/google-appengine/python:latest',
         help='Name of Docker image to use as base')
+    # In some cases, gcloud sets an environment variable to indicate
+    # the location of the application configuration file, rather than
+    # using the --config flag.  The order of precedence from highest
+    # to lowest is:
+    #
+    # 1) --config flag
+    # 2) $GAE_APPLICATION_YAML_PATH environment variable
+    # 3) a file named "app.yaml" in the current working directory
     parser.add_argument(
         '--config',
         type=functools.partial(
             validation_utils.validate_arg_regex, flag_regex=PRINTABLE_REGEX),
-        default='app.yaml',
+        default=(os.environ.get(GAE_APPLICATION_YAML_PATH) or 'app.yaml'),
         help='Path to application configuration file'
         )
     parser.add_argument(

--- a/scripts/gen_dockerfile_test.py
+++ b/scripts/gen_dockerfile_test.py
@@ -225,5 +225,26 @@ def test_parse_args_invalid(argv):
             gen_dockerfile.parse_args(argv)
 
 
+@pytest.mark.parametrize('argv, env, expected', [
+    # Explicit flag wins
+    (['argv0', '--config=flag/path'], 'env/path', 'flag/path'),
+    (['argv0', '--config=flag/path'], '', 'flag/path'),
+    (['argv0', '--config=flag/path'], None, 'flag/path'),
+    # Otherwise env var wins
+    (['argv0'], 'env/path', 'env/path'),
+    # Otherwise use default name
+    (['argv0'], '', 'app.yaml'),
+    (['argv0'], None, 'app.yaml'),
+])
+def test_parse_args_config(argv, env, expected):
+    if env is None:
+        mock_environ = {}
+    else:
+        mock_environ = {gen_dockerfile.GAE_APPLICATION_YAML_PATH: env}
+    with unittest.mock.patch.dict('os.environ', mock_environ, clear=True):
+        args = gen_dockerfile.parse_args(argv)
+        assert args.config == expected
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
In some cases, gcloud sets an environment variable to indicate
the location of the application configuration file, rather than
using the --config flag.