### PR TITLE
Increase timeout for library compatibility test

### DIFF
--- a/cloudbuild_library_tests.yaml
+++ b/cloudbuild_library_tests.yaml
@@ -1,3 +1,4 @@
+timeout: 1800s
 steps:
 - # Check that we can install important libraries without error
   name: gcr.io/gcp-runtimes/structure_test:latest


### PR DESCRIPTION
Timeout was 10 minutes, now is 30 minutes.  Build currently takes about 20 minutes.