### PR TITLE
Fix Dockerfile reference to deleted directory.

### DIFF
--- a/python-interpreter-builder/Dockerfile.in
+++ b/python-interpreter-builder/Dockerfile.in
@@ -43,7 +43,6 @@ ENV LANG C.UTF-8
 
 # Add build scripts
 ADD scripts /scripts
-ADD patches /patches
 
 # Build the Python interpreters
 RUN /scripts/build-python-3.5.sh


### PR DESCRIPTION
The `patches` directory was implicitly removed in #142 when we deleted the last file in it.  However, this wasn't found in testing because my local client still had a patches directory.