### PR TITLE
Add missing dependency

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -5,3 +5,4 @@ google-cloud-monitoring==0.27.0
 gunicorn==19.7.1
 requests==2.18.4
 retrying==1.3.3
+six==1.11.0


### PR DESCRIPTION
It was using a too-old version of six in some cases, leading to this error:

```  
File "/usr/local/lib/python2.7/dist-packages/google/api/core/exceptions.py", line 43, in <module>
    @six.python_2_unicode_compatible
AttributeError: 'module' object has no attribute 'python_2_unicode_compatible'
```