### PR TITLE
Migrate structure tests to new version

### DIFF
--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -1,7 +1,27 @@
 timeout: 3600s
 steps:
-- # Validate structure of base runtime image
-  name: gcr.io/gcp-runtimes/structure_test:latest
+ # Validate structure of base runtime image
+- name: gcr.io/cloud-builders/docker:latest
+  args: ['build', '-t', 'python2-libraries-intermediate', '--build-arg', 
+         'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
+         '/workspace/tests/python2-libraries']
+- name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
+  args: [
+    '-test.v',
+    '-image', 'python2-libraries-intermediate',
+    '/workspace/tests/python2-libraries/python2-libraries.yaml'
+  ]
+- name: gcr.io/cloud-builders/docker:latest
+  args: ['build', '-t', 'python3-libraries-intermediate', '--build-arg', 
+         'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
+         '/workspace/tests/python3-libraries']
+- name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
+  args: [
+    '-test.v',
+    '-image', 'python3-libraries-intermediate',
+    '/workspace/tests/python3-libraries/python3-libraries.yaml'
+  ]
+- name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
   args: [
     '-i', '${_DOCKER_NAMESPACE}/python:${_TAG}',
     '--config', '/workspace/tests/virtualenv/virtualenv_default.yaml',
@@ -9,8 +29,6 @@ steps:
     '--config', '/workspace/tests/virtualenv/virtualenv_python35.yaml',
     '--config', '/workspace/tests/virtualenv/virtualenv_python36.yaml',
     '--config', '/workspace/tests/no-virtualenv/no-virtualenv.yaml',
-    '--config', '/workspace/tests/python2-libraries/python2-libraries.yaml',
-    '--config', '/workspace/tests/python3-libraries/python3-libraries.yaml',
     '--config', '/workspace/tests/license-test/license-test.yaml',
     '-v'
     ]
@@ -24,5 +42,4 @@ steps:
          '--no-cache', '/workspace/tests/google-cloud-python/']
 - # Run google client library unit tests
   name: ${_DOCKER_NAMESPACE}/python/tests/google-cloud-python:${_TAG}
-images: [
-]
+images: []

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -23,14 +23,14 @@ steps:
   ]
 - name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
   args: [
-    '-i', '${_DOCKER_NAMESPACE}/python:${_TAG}',
-    '--config', '/workspace/tests/virtualenv/virtualenv_default.yaml',
-    '--config', '/workspace/tests/virtualenv/virtualenv_python34.yaml',
-    '--config', '/workspace/tests/virtualenv/virtualenv_python35.yaml',
-    '--config', '/workspace/tests/virtualenv/virtualenv_python36.yaml',
-    '--config', '/workspace/tests/no-virtualenv/no-virtualenv.yaml',
-    '--config', '/workspace/tests/license-test/license-test.yaml',
-    '-v'
+    '-test.v',
+    '-image', '${_DOCKER_NAMESPACE}/python:${_TAG}',
+    '/workspace/tests/virtualenv/virtualenv_default.yaml',
+    '/workspace/tests/virtualenv/virtualenv_python34.yaml',
+    '/workspace/tests/virtualenv/virtualenv_python35.yaml',
+    '/workspace/tests/virtualenv/virtualenv_python36.yaml',
+    '/workspace/tests/no-virtualenv/no-virtualenv.yaml',
+    '/workspace/tests/license-test/license-test.yaml'
     ]
 - # Run compatibility tests
   name: gcr.io/cloud-builders/docker:latest

--- a/tests/python2-libraries/Dockerfile
+++ b/tests/python2-libraries/Dockerfile
@@ -1,0 +1,3 @@
+ARG intermediate_image
+FROM $intermediate_image
+COPY requirements.txt /requirements.txt

--- a/tests/python2-libraries/python2-libraries.yaml
+++ b/tests/python2-libraries/python2-libraries.yaml
@@ -7,10 +7,7 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "virtual env teardown"
-    command: ["rm", "-rf", "/env"]
-
   - name: "requirements"
     setup: [["virtualenv", "/env"]]
-    command: ["pip", "install", "-r", "/workspace/tests/python2-libraries/requirements.txt"]
+    command: ["pip", "install", "-r", "/requirements.txt"]
     exitCode: 0

--- a/tests/python3-libraries/Dockerfile
+++ b/tests/python3-libraries/Dockerfile
@@ -1,0 +1,3 @@
+ARG intermediate_image
+FROM $intermediate_image
+COPY requirements.txt /requirements.txt

--- a/tests/python3-libraries/python3-libraries.yaml
+++ b/tests/python3-libraries/python3-libraries.yaml
@@ -8,15 +8,11 @@ globalEnvVars:
 
 commandTests:
   - name: "requirements 3.5"
-    setup:
-      - ["rm", "-rf", "/env"]
-      - ["virtualenv", "-p", "/opt/python3.5/bin/python3.5", "/env"]
-    command: ["pip", "install", "-r", "/workspace/tests/python3-libraries/requirements.txt"]
+    setup: [["virtualenv", "-p", "/opt/python3.5/bin/python3.5", "/env"]]
+    command: ["pip", "install", "-r", "/requirements.txt"]
     exitCode: 0
 
   - name: "requirements 3.6"
-    setup:
-      - ["rm", "-rf", "/env"]
-      - ["virtualenv", "-p", "/opt/python3.6/bin/python3.6", "/env"]
-    command: ["pip", "install", "-r", "/workspace/tests/python3-libraries/requirements.txt"]
+    setup: [["virtualenv", "-p", "/opt/python3.6/bin/python3.6", "/env"]]
+    command: ["pip", "install", "-r", "/requirements.txt"]
     exitCode: 0

--- a/tests/virtualenv/virtualenv_default.yaml
+++ b/tests/virtualenv/virtualenv_default.yaml
@@ -7,12 +7,13 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "virtual env teardown"
-    command: ["rm", "-rf", "/env"]
-
   - name: "python installation"
     command: ["which", "python"]
     expectedOutput: ["/usr/bin/python\n"]
+
+  - name: "pip installation"
+    command: ["which", "pip"]
+    expectedOutput: ["/usr/local/bin/pip\n"]
 
   - name: "virtualenv installation"
     setup: [["virtualenv", "/env"]]
@@ -25,12 +26,13 @@ commandTests:
     # https://bugs.python.org/issue18338
     expectedError: ["Python 2.7.9\n"]
 
-  - name: "pip installation"
+  - name: "virtualenv pip installation"
+    setup: [["virtualenv", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
-  - name: "gunicorn flask"
-    setup: [["pip", "install", "gunicorn", "flask"]]
+  - name: "virtualenv gunicorn flask"
+    setup: [["virtualenv", "/env"], ["pip", "install", "gunicorn", "flask"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
       

--- a/tests/virtualenv/virtualenv_python34.yaml
+++ b/tests/virtualenv/virtualenv_python34.yaml
@@ -7,9 +7,6 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "virtual env teardown"
-    command: ["rm", "-rf", "/env"]
-
   - name: "python installation"
     command: ["which", "python3.4"]
     expectedOutput: ["/usr/bin/python3.4\n"]
@@ -20,23 +17,27 @@ commandTests:
     expectedOutput: ["/env/bin/python\n"]
 
   - name: "virtualenv python3 installation"
+    setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "python3"]
     expectedOutput: ["/env/bin/python3\n"]
 
   - name: "python version"
+    setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["python", "--version"]
     expectedOutput: ["Python 3.4.2\n"]
 
   - name: "pip installation"
+    setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
   - name: "pip3 installation"
+    setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "pip3"]
     expectedOutput: ["/env/bin/pip3\n"]
 
   - name: "gunicorn flask"
-    setup: [["pip", "install", "gunicorn", "flask"]]
+    setup: [["virtualenv", "-p", "python3.4", "/env"], ["pip", "install", "gunicorn", "flask"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
 

--- a/tests/virtualenv/virtualenv_python35.yaml
+++ b/tests/virtualenv/virtualenv_python35.yaml
@@ -20,27 +20,32 @@ commandTests:
     expectedOutput: ["/env/bin/python\n"]
 
   - name: "virtualenv python3 installation"
+    setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "python3"]
     expectedOutput: ["/env/bin/python3\n"]
 
   - name: "virtualenv python3.5 installation"
+    setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "python3.5"]
     expectedOutput: ["/env/bin/python3.5\n"]
 
   - name: "python version"
+    setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["python", "--version"]
     expectedOutput: ["Python 3.5.4\n"]
 
   - name: "pip installation"
+    setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
   - name: "pip3 installation"
+    setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "pip3"]
     expectedOutput: ["/env/bin/pip3\n"]
 
   - name: "gunicorn flask"
-    setup: [["pip", "install", "gunicorn", "flask"]]
+    setup: [["virtualenv", "-p", "python3.5", "/env"], ["pip", "install", "gunicorn", "flask"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
 

--- a/tests/virtualenv/virtualenv_python36.yaml
+++ b/tests/virtualenv/virtualenv_python36.yaml
@@ -20,27 +20,32 @@ commandTests:
     expectedOutput: ["/env/bin/python\n"]
 
   - name: "virtualenv python3 installation"
+    setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "python3"]
     expectedOutput: ["/env/bin/python3\n"]
 
   - name: "virtualenv python3.6 installation"
+    setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "python3.6"]
     expectedOutput: ["/env/bin/python3.6\n"]
 
   - name: "python version"
+    setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["python", "--version"]
     expectedOutput: ["Python 3.6.2\n"]
 
   - name: "pip installation"
+    setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
   - name: "pip3 installation"
+    setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "pip3"]
     expectedOutput: ["/env/bin/pip3\n"]
 
   - name: "gunicorn flask"
-    setup: [["pip", "install", "gunicorn", "flask"]]
+    setup: [["virtualenv", "-p", "python3.6", "/env"], ["pip", "install", "gunicorn", "flask"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
 


### PR DESCRIPTION
This moves the structure tests to run on the latest version (**v0.1.1**) of the [container-structure-test](https://github.com/GoogleCloudPlatform/container-structure-test) framework. The newest version removes the concept of a test "state", meaning every test is run in isolation; this means we need to run setup commands on each individual command, rather than relying on test ordering in the config.

Additionally, the framework itself does not run the test image as a docker container inside itself anymore, meaning we can't reference external files (namely, `/workspace`). To work around this, I built small intermediate images based on the image under test that copy in necessary files for the tests that needed them.

This should have no functional change to the build.