### PR TITLE
Revert to previous virtualenv behavior.

### DIFF
--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -26,6 +26,7 @@ steps:
     '-test.v',
     '-image', '${_DOCKER_NAMESPACE}/python:${_TAG}',
     '/workspace/tests/virtualenv/virtualenv_default.yaml',
+    '/workspace/tests/virtualenv/virtualenv_python27.yaml',
     '/workspace/tests/virtualenv/virtualenv_python34.yaml',
     '/workspace/tests/virtualenv/virtualenv_python35.yaml',
     '/workspace/tests/virtualenv/virtualenv_python36.yaml',

--- a/runtime-image/Dockerfile.in
+++ b/runtime-image/Dockerfile.in
@@ -27,7 +27,8 @@ ENV PATH /opt/python3.6/bin:/opt/python3.5/bin:$PATH
 RUN /usr/bin/pip install --upgrade -r /resources/requirements.txt && \
     /usr/bin/pip3 install --upgrade -r /resources/requirements.txt && \
     /opt/python3.5/bin/pip3.5 install --upgrade -r /resources/requirements.txt && \
-    /opt/python3.6/bin/pip3.6 install --upgrade -r /resources/requirements.txt
+    /opt/python3.6/bin/pip3.6 install --upgrade -r /resources/requirements.txt && \
+    /usr/bin/pip install --upgrade -r /resources/requirements-virtualenv.txt
 
 # Setup the app working directory
 RUN ln -s /home/vmagent/app /app

--- a/runtime-image/resources/requirements-virtualenv.txt
+++ b/runtime-image/resources/requirements-virtualenv.txt
@@ -1,0 +1,1 @@
+virtualenv==15.1.0

--- a/runtime-image/resources/requirements.txt
+++ b/runtime-image/resources/requirements.txt
@@ -1,3 +1,3 @@
 pip==9.0.1
 setuptools==36.6.0
-virtualenv==15.1.0
+wheel==0.30.0

--- a/tests/no-virtualenv/no-virtualenv.yaml
+++ b/tests/no-virtualenv/no-virtualenv.yaml
@@ -4,7 +4,41 @@ commandTests:
     command: ["which", "python"]
     expectedOutput: ["/usr/bin/python\n"]
 
+  - name: "default pip installation"
+    command: ["which", "pip"]
+    expectedOutput: ["/usr/local/bin/pip\n"]
+
+  - name: "default pip python version"
+    command: ["pip", "-V"]
+    expectedOutput: ["pip .* from .* (python 2.7)"]
+
+  - name: "default virtualenv installation"
+    command: ["which", "virtualenv"]
+    expectedOutput: ["/usr/local/bin/virtualenv\n"]
+
+  - name: "default python2.7 installation"
+    command: ["which", "python2.7"]
+    expectedOutput: ["/usr/bin/python2.7\n"]
+
+  - name: "default python3.4 installation"
+    command: ["which", "python3.4"]
+    expectedOutput: ["/usr/bin/python3.4\n"]
+
+  - name: "default python3.5 installation"
+    command: ["which", "python3.5"]
+    expectedOutput: ["/opt/python3.5/bin/python3.5\n"]
+
+  - name: "default python3.6 installation"
+    command: ["which", "python3.6"]
+    expectedOutput: ["/opt/python3.6/bin/python3.6\n"]
+
   - name: "default gunicorn installation"
     setup: [["pip", "install", "gunicorn"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/usr/local/bin/gunicorn\n"]
+
+  - name: "default flask installation"
+    # Checks that 'pip' and 'python' are using the same Python version
+    setup: [["pip", "install", "flask"]]
+    command: ["python", "-c", "import flask; print(flask.__file__)"]
+    expectedOutput: ["/usr/local/lib/python2.7/dist-packages/flask"]

--- a/tests/no-virtualenv/no-virtualenv.yaml
+++ b/tests/no-virtualenv/no-virtualenv.yaml
@@ -10,7 +10,7 @@ commandTests:
 
   - name: "default pip python version"
     command: ["pip", "-V"]
-    expectedOutput: ["pip .* from .* (python 2.7)"]
+    expectedOutput: ["pip .* from .*python 2[.]7"]
 
   - name: "default virtualenv installation"
     command: ["which", "virtualenv"]

--- a/tests/python2-libraries/python2-libraries.yaml
+++ b/tests/python2-libraries/python2-libraries.yaml
@@ -8,6 +8,6 @@ globalEnvVars:
 
 commandTests:
   - name: "requirements"
-    setup: [["virtualenv", "/env"]]
+    setup: [["virtualenv", "-p", "python", "/env"]]
     command: ["pip", "install", "-r", "/requirements.txt"]
     exitCode: 0

--- a/tests/virtualenv/virtualenv_default.yaml
+++ b/tests/virtualenv/virtualenv_default.yaml
@@ -7,20 +7,13 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "python installation"
-    command: ["which", "python"]
-    expectedOutput: ["/usr/bin/python\n"]
-
-  - name: "pip installation"
-    command: ["which", "pip"]
-    expectedOutput: ["/usr/local/bin/pip\n"]
-
-  - name: "virtualenv installation"
+  - name: "virtualenv python installation"
     setup: [["virtualenv", "/env"]]
     command: ["which", "python"]
     expectedOutput: ["/env/bin/python\n"]
 
-  - name: "python version"
+  - name: "virtualenv python version"
+    setup: [["virtualenv", "/env"]]
     command: ["python", "--version"]
     # we check stderr instead of stdout for Python versions < 3.4
     # https://bugs.python.org/issue18338
@@ -31,10 +24,14 @@ commandTests:
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
-  - name: "virtualenv gunicorn flask"
-    setup: [["virtualenv", "/env"], ["pip", "install", "gunicorn", "flask"]]
+  - name: "virtualenv gunicorn installation"
+    setup: [["virtualenv", "/env"],
+            ["pip", "install", "gunicorn"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
       
-  - name: "flask integration"
-    command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+  - name: "virtualenv flask installation"
+    setup: [["virtualenv", "/env"],
+            ["pip", "install", "flask"]]
+    command: ["python", "-c", "import flask; print(flask.__file__)"]
+    expectedOutput: ["/usr/local/lib/python2.7/dist-packages/flask"]

--- a/tests/virtualenv/virtualenv_default.yaml
+++ b/tests/virtualenv/virtualenv_default.yaml
@@ -34,4 +34,4 @@ commandTests:
     setup: [["virtualenv", "/env"],
             ["pip", "install", "flask"]]
     command: ["python", "-c", "import flask; print(flask.__file__)"]
-    expectedOutput: ["/usr/local/lib/python2.7/site-packages/flask"]
+    expectedOutput: ["/env/local/lib/python2.7/site-packages/flask"]

--- a/tests/virtualenv/virtualenv_default.yaml
+++ b/tests/virtualenv/virtualenv_default.yaml
@@ -34,4 +34,4 @@ commandTests:
     setup: [["virtualenv", "/env"],
             ["pip", "install", "flask"]]
     command: ["python", "-c", "import flask; print(flask.__file__)"]
-    expectedOutput: ["/usr/local/lib/python2.7/dist-packages/flask"]
+    expectedOutput: ["/usr/local/lib/python2.7/site-packages/flask"]

--- a/tests/virtualenv/virtualenv_python27.yaml
+++ b/tests/virtualenv/virtualenv_python27.yaml
@@ -44,4 +44,4 @@ commandTests:
     setup: [["virtualenv", "-p", "python", "/env"],
             ["pip", "install", "flask"]]
     command: ["python", "-c", "import flask; print(flask.__file__)"]
-    expectedOutput: ["/env/lib/python2.7/dist-packages/flask"]
+    expectedOutput: ["/env/local/lib/python2.7/site-packages/flask"]

--- a/tests/virtualenv/virtualenv_python27.yaml
+++ b/tests/virtualenv/virtualenv_python27.yaml
@@ -1,0 +1,47 @@
+schemaVersion: "1.0.0"
+
+globalEnvVars:
+  - key: "VIRTUAL_ENV"
+    value: "/env"
+  - key: "PATH"
+    value: "/env/bin:$PATH"
+
+commandTests:
+  - name: "virtualenv27 python installation"
+    setup: [["virtualenv", "-p", "python", "/env"]]
+    command: ["which", "python"]
+    expectedOutput: ["/env/bin/python\n"]
+
+  - name: "virtualenv27 python2 installation"
+    setup: [["virtualenv", "-p", "python", "/env"]]
+    command: ["which", "python2"]
+    expectedOutput: ["/env/bin/python2\n"]
+
+  - name: "virtualenv27python2.7 installation"
+    setup: [["virtualenv", "-p", "python", "/env"]]
+    command: ["which", "python2.7"]
+    expectedOutput: ["/env/bin/python2.7\n"]
+
+  - name: "virtualenv27 python version"
+    setup: [["virtualenv", "-p", "python", "/env"]]
+    command: ["python", "--version"]
+    # we check stderr instead of stdout for Python versions < 3.4
+    # https://bugs.python.org/issue18338
+    expectedError: ["Python 2.7.9\n"]
+
+  - name: "virtualenv27 pip installation"
+    setup: [["virtualenv", "-p", "python", "/env"]]
+    command: ["which", "pip"]
+    expectedOutput: ["/env/bin/pip\n"]
+
+  - name: "virtualenv27 gunicorn installation"
+    setup: [["virtualenv", "-p", "python", "/env"],
+            ["pip", "install", "gunicorn"]]
+    command: ["which", "gunicorn"]
+    expectedOutput: ["/env/bin/gunicorn"]
+
+  - name: "virtualenv27 flask installation"
+    setup: [["virtualenv", "-p", "python", "/env"],
+            ["pip", "install", "flask"]]
+    command: ["python", "-c", "import flask; print(flask.__file__)"]
+    expectedOutput: ["/env/lib/python2.7/dist-packages/flask"]

--- a/tests/virtualenv/virtualenv_python34.yaml
+++ b/tests/virtualenv/virtualenv_python34.yaml
@@ -7,42 +7,48 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "python installation"
-    command: ["which", "python3.4"]
-    expectedOutput: ["/usr/bin/python3.4\n"]
-
-  - name: "virtualenv python installation"
+  - name: "virtualenv34 python installation"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "python"]
     expectedOutput: ["/env/bin/python\n"]
 
-  - name: "virtualenv python3 installation"
+  - name: "virtualenv34 python3 installation"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "python3"]
     expectedOutput: ["/env/bin/python3\n"]
 
-  - name: "python version"
+  - name: "virtualenv34 python3.4 installation"
+    setup: [["virtualenv", "-p", "python3.4", "/env"]]
+    command: ["which", "python3.4"]
+    expectedOutput: ["/env/bin/python3.4\n"]
+
+  - name: "virtualenv34 python version"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["python", "--version"]
     expectedOutput: ["Python 3.4.2\n"]
 
-  - name: "pip installation"
+  - name: "virtualenv34 pip installation"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
-  - name: "pip3 installation"
+  - name: "virtualenv34 pip3 installation"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["which", "pip3"]
     expectedOutput: ["/env/bin/pip3\n"]
 
-  - name: "gunicorn flask"
-    setup: [["virtualenv", "-p", "python3.4", "/env"], ["pip", "install", "gunicorn", "flask"]]
+  - name: "virtualenv34 gunicorn installation"
+    setup: [["virtualenv", "-p", "python3.4", "/env"],
+            ["pip", "install", "gunicorn"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
 
-  - name: "flask integration"
-    command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+  - name: "virtualenv34 flask installation"
+    setup: [["virtualenv", "-p", "python3.4", "/env"],
+            ["pip", "install", "flask"]]
+    command: ["python", "-c", "import flask; print(flask.__file__)"]
+    expectedOutput: ["/env/lib/python3.4/site-packages/flask"]
 
-  - name: "test.support"
+  - name: "virtualenv34 test.support availability"
+    setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["python", "-c", "\"from test import pystone, regrtest, support\""]

--- a/tests/virtualenv/virtualenv_python35.yaml
+++ b/tests/virtualenv/virtualenv_python35.yaml
@@ -7,50 +7,48 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "virtual env teardown"
-    command: ["rm", "-rf", "/env"]
-
-  - name: "python installation"
-    command: ["which", "python3.5"]
-    expectedOutput: ["/opt/python3.5/bin/python3.5\n"]
-
-  - name: "virtualenv python installation"
+  - name: "virtualenv35 python installation"
     setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "python"]
     expectedOutput: ["/env/bin/python\n"]
 
-  - name: "virtualenv python3 installation"
+  - name: "virtualenv35 python3 installation"
     setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "python3"]
     expectedOutput: ["/env/bin/python3\n"]
 
-  - name: "virtualenv python3.5 installation"
+  - name: "virtualenv35 python3.5 installation"
     setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "python3.5"]
     expectedOutput: ["/env/bin/python3.5\n"]
 
-  - name: "python version"
+  - name: "virtualenv35 python version"
     setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["python", "--version"]
     expectedOutput: ["Python 3.5.4\n"]
 
-  - name: "pip installation"
+  - name: "virtualenv35 pip installation"
     setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
-  - name: "pip3 installation"
+  - name: "virtualenv35 pip3 installation"
     setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["which", "pip3"]
     expectedOutput: ["/env/bin/pip3\n"]
 
-  - name: "gunicorn flask"
-    setup: [["virtualenv", "-p", "python3.5", "/env"], ["pip", "install", "gunicorn", "flask"]]
+  - name: "virtualenv35 gunicorn installation"
+    setup: [["virtualenv", "-p", "python3.5", "/env"],
+            ["pip", "install", "gunicorn"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
 
-  - name: "flask integration"
-    command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+  - name: "virtualenv35 flask installation"
+    setup: [["virtualenv", "-p", "python3.5", "/env"],
+            ["pip", "install", "flask"]]
+    command: ["python", "-c", "import flask; print(flask.__file__)"]
+    expectedOutput: ["/env/lib/python3.5/site-packages/flask"]
 
-  - name: "test.support"
+  - name: "virtualenv35 test.support availability"
+    setup: [["virtualenv", "-p", "python3.5", "/env"]]
     command: ["python", "-c", "\"from test import pystone, regrtest, support\""]

--- a/tests/virtualenv/virtualenv_python36.yaml
+++ b/tests/virtualenv/virtualenv_python36.yaml
@@ -7,50 +7,48 @@ globalEnvVars:
     value: "/env/bin:$PATH"
 
 commandTests:
-  - name: "virtual env teardown"
-    command: ["rm", "-rf", "/env"]
-
-  - name: "python installation"
-    command: ["which", "python3.6"]
-    expectedOutput: ["/opt/python3.6/bin/python3.6\n"]
-
-  - name: "virtualenv python installation"
+  - name: "virtualenv36 python installation"
     setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "python"]
     expectedOutput: ["/env/bin/python\n"]
 
-  - name: "virtualenv python3 installation"
+  - name: "virtualenv36 python3 installation"
     setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "python3"]
     expectedOutput: ["/env/bin/python3\n"]
 
-  - name: "virtualenv python3.6 installation"
+  - name: "virtualenv36 python3.6 installation"
     setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "python3.6"]
     expectedOutput: ["/env/bin/python3.6\n"]
 
-  - name: "python version"
+  - name: "virtualenv36 python version"
     setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["python", "--version"]
     expectedOutput: ["Python 3.6.2\n"]
 
-  - name: "pip installation"
+  - name: "virtualenv36 pip installation"
     setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "pip"]
     expectedOutput: ["/env/bin/pip\n"]
 
-  - name: "pip3 installation"
+  - name: "virtualenv36 pip3 installation"
     setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["which", "pip3"]
     expectedOutput: ["/env/bin/pip3\n"]
 
-  - name: "gunicorn flask"
-    setup: [["virtualenv", "-p", "python3.6", "/env"], ["pip", "install", "gunicorn", "flask"]]
+  - name: "virtualenv36 gunicorn installation"
+    setup: [["virtualenv", "-p", "python3.6", "/env"],
+            ["pip", "install", "gunicorn"]]
     command: ["which", "gunicorn"]
     expectedOutput: ["/env/bin/gunicorn"]
 
-  - name: "flask integration"
-    command: ["python", "-c", "\"import sys; import flask; sys.exit(0 if flask.__file__.startswith('/env') else 1)\""]
+  - name: "virtualenv36 flask installation"
+    setup: [["virtualenv", "-p", "python3.6", "/env"],
+            ["pip", "install", "flask"]]
+    command: ["python", "-c", "import flask; print(flask.__file__)"]
+    expectedOutput: ["/env/lib/python3.6/site-packages/flask"]
 
-  - name: "test.support"
+  - name: "virtualenv36 test.support availability"
+    setup: [["virtualenv", "-p", "python3.6", "/env"]]
     command: ["python", "-c", "\"from test import pystone, regrtest, support\""]


### PR DESCRIPTION
A previous change (#161) caused the 'virtualenv' command change to switch its
default Python version from 2.7 to 3.6 (when no -p flag is passed).
Although not a bad change, it was accidental, and this reverts to the
previous behavior.  This also add tests for the behavior, and fixes
various tests that had been subtly broken by a previous refactoring.

The cause of this behavior change was that the 'virtualenv' package
was installed under each Python interpreter, instead of the 'wheel'
package.