### PR TITLE
Python compat

### DIFF
--- a/scripts/data/Dockerfile.python_compat
+++ b/scripts/data/Dockerfile.python_compat
@@ -1,0 +1,3 @@
+FROM gcr.io/google_appengine/python-compat-multicore
+ADD . /app/
+RUN if [ -s requirements.txt ]; then pip install -r requirements.txt; fi

--- a/scripts/data/dockerignore.python_compat
+++ b/scripts/data/dockerignore.python_compat
@@ -1,0 +1,5 @@
+.dockerignore
+Dockerfile
+.git
+.hg
+.svn

--- a/scripts/gen_dockerfile.py
+++ b/scripts/gen_dockerfile.py
@@ -213,8 +213,9 @@ def generate_dockerfile_command(base_image, config_file, source_dir):
 
     # Short circuit for python compat.
     if validation_utils.get_field_value(
-        raw_runtime_config, 'runtime_id', str) == 'python-compat':
-      files = {'Dockerfile': COMPAT_DOCKERFILE}
+        raw_config, 'runtime_id', str) == 'python-compat':
+      files = {'Dockerfile': COMPAT_DOCKERFILE,
+               '.dockerignore': get_data('dockerignore'),}
     else:
       # Determine complete configuration
       app_config = get_app_config(raw_config, base_image, config_file,

--- a/scripts/gen_dockerfile.py
+++ b/scripts/gen_dockerfile.py
@@ -62,7 +62,7 @@ GAE_APPLICATION_YAML_PATH = 'GAE_APPLICATION_YAML_PATH'
 # Validated application configuration
 AppConfig = collections.namedtuple(
     'AppConfig',
-    'base_image dockerfile_python_version entrypoint has_requirements_txt, is_python_compat'
+    'base_image dockerfile_python_version entrypoint has_requirements_txt is_python_compat'
 )
 
 
@@ -187,7 +187,7 @@ def generate_files(app_config):
 
     if app_config.is_python_compat:
       dockerfile = get_data('Dockerfile.python_compat')
-      dockerignore =  get_data('dockerignore.python_compat')
+      dockerignore = get_data('dockerignore.python_compat')
     else:
       dockerfile = ''.join([
           get_data('Dockerfile.preamble.template').format(

--- a/scripts/gen_dockerfile_test.py
+++ b/scripts/gen_dockerfile_test.py
@@ -155,7 +155,7 @@ _BASE_APP_CONFIG = gen_dockerfile.AppConfig(
     # Python version
     (_BASE_APP_CONFIG._replace(dockerfile_python_version='_my_version'), True,
      'python_version=python_my_version'),
-    # Python version
+    # python-compat runtime
     (_BASE_APP_CONFIG._replace(is_python_compat=True), True,
      'FROM gcr.io/google_appengine/python-compat-multicore'),
 ])

--- a/scripts/gen_dockerfile_test.py
+++ b/scripts/gen_dockerfile_test.py
@@ -163,10 +163,12 @@ def compare_against_golden_files(app, config_dir, testdata_dir):
         compare_file(filename, config_dir, golden_dir)
 
 
-def test_generate_dockerfile_command(tmpdir, testdata_dir):
+@pytest.mark.parametrize('app', [
+    # Sampled from https://github.com/GoogleCloudPlatform/python-docs-samples
+    'hello_world',
+    'hello_world_compat'])
+def test_generate_dockerfile_command(tmpdir, testdata_dir, app):
     """Generates output and compares against a set of golden files."""
-    # Sample from https://github.com/GoogleCloudPlatform/python-docs-samples
-    app = 'hello_world'
     app_dir = os.path.join(testdata_dir, app)
 
     # Copy sample app to writable temp dir, and generate Dockerfile.
@@ -179,12 +181,14 @@ def test_generate_dockerfile_command(tmpdir, testdata_dir):
     compare_against_golden_files(app, config_dir, testdata_dir)
 
 
+@pytest.mark.parametrize('app', [
+    # Sampled from https://github.com/GoogleCloudPlatform/python-docs-samples
+    'hello_world',
+    'hello_world_compat'])
 @pytest.mark.xfail(not shutil.which('gcloud'),
                    reason='Google Cloud SDK is not installed')
-def test_generate_dockerfile_golden(tmpdir, testdata_dir):
+def test_generate_dockerfile_golden(tmpdir, testdata_dir, app):
     """Validate our golden files against gcloud app gen-config"""
-    # Sample from https://github.com/GoogleCloudPlatform/python-docs-samples
-    app = 'hello_world'
     app_dir = os.path.join(testdata_dir, app)
 
     # Copy sample app to writable temp dir, and generate Dockerfile.

--- a/scripts/gen_dockerfile_test.py
+++ b/scripts/gen_dockerfile_test.py
@@ -54,6 +54,14 @@ def compare_file(filename, dir1, dir2):
         'dockerfile_python_version': '',
         'has_requirements_txt': False,
         'entrypoint': '',
+        'is_python_compat': False,
+    }),
+    ('env: flex\nruntime: python-compat', {
+        'base_image': None,
+        'dockerfile_python_version': None,
+        'has_requirements_txt': None,
+        'entrypoint': None,
+        'is_python_compat': True,
     }),
     # All supported python versions
     ('runtime_config:\n python_version:', {
@@ -125,7 +133,8 @@ _BASE_APP_CONFIG = gen_dockerfile.AppConfig(
     base_image='',
     dockerfile_python_version='',
     entrypoint='',
-    has_requirements_txt=False
+    has_requirements_txt=False,
+    is_python_compat=False,
 )
 
 
@@ -146,6 +155,9 @@ _BASE_APP_CONFIG = gen_dockerfile.AppConfig(
     # Python version
     (_BASE_APP_CONFIG._replace(dockerfile_python_version='_my_version'), True,
      'python_version=python_my_version'),
+    # Python version
+    (_BASE_APP_CONFIG._replace(is_python_compat=True), True,
+     'FROM gcr.io/google_appengine/python-compat-multicore'),
 ])
 def test_generate_files(app_config, should_find, test_string):
     result = gen_dockerfile.generate_files(app_config)
@@ -166,6 +178,7 @@ def compare_against_golden_files(app, config_dir, testdata_dir):
 @pytest.mark.parametrize('app', [
     # Sampled from https://github.com/GoogleCloudPlatform/python-docs-samples
     'hello_world',
+    # From an internal source.
     'hello_world_compat'])
 def test_generate_dockerfile_command(tmpdir, testdata_dir, app):
     """Generates output and compares against a set of golden files."""
@@ -184,6 +197,7 @@ def test_generate_dockerfile_command(tmpdir, testdata_dir, app):
 @pytest.mark.parametrize('app', [
     # Sampled from https://github.com/GoogleCloudPlatform/python-docs-samples
     'hello_world',
+    # From an internal source.
     'hello_world_compat'])
 @pytest.mark.xfail(not shutil.which('gcloud'),
                    reason='Google Cloud SDK is not installed')

--- a/scripts/testdata/hello_world_compat/app.yaml
+++ b/scripts/testdata/hello_world_compat/app.yaml
@@ -1,0 +1,25 @@
+service: default
+runtime: custom
+env: flex
+
+api_version: 1
+threadsafe: true
+
+beta_settings:
+  enable_app_engine_apis: true # Needed for compat apps.
+  # allow_ssh: true
+  # auto_restart: false
+  # use_regional: false
+  # image: canary
+  # image: projects/goog-vmruntime-images/global/images/debian-7-wheezy-v2016-06-27a
+
+resources:
+  cpu: 1
+  memory_gb: 1.3
+
+manual_scaling:
+  instances: 2
+
+handlers:
+- url: .*
+  script: main.app

--- a/scripts/testdata/hello_world_compat/app.yaml
+++ b/scripts/testdata/hello_world_compat/app.yaml
@@ -1,5 +1,5 @@
 service: default
-runtime: custom
+runtime: python-compat
 env: flex
 
 api_version: 1
@@ -7,18 +7,6 @@ threadsafe: true
 
 beta_settings:
   enable_app_engine_apis: true # Needed for compat apps.
-  # allow_ssh: true
-  # auto_restart: false
-  # use_regional: false
-  # image: canary
-  # image: projects/goog-vmruntime-images/global/images/debian-7-wheezy-v2016-06-27a
-
-resources:
-  cpu: 1
-  memory_gb: 1.3
-
-manual_scaling:
-  instances: 2
 
 handlers:
 - url: .*

--- a/scripts/testdata/hello_world_compat/main.py
+++ b/scripts/testdata/hello_world_compat/main.py
@@ -1,0 +1,14 @@
+"""The hello world flex app!"""
+
+import webapp2
+
+
+class HelloHandler(webapp2.RequestHandler):
+
+  def get(self):
+    msg = 'Hello GAE Flex (env: flex) Compat-Runtime App\n'
+    self.response.headers['Content-Type'] = 'text/plain'
+    self.response.out.write(msg)
+
+app = webapp2.WSGIApplication([('/', HelloHandler)],
+                              debug=True)

--- a/scripts/testdata/hello_world_compat_golden/.dockerignore
+++ b/scripts/testdata/hello_world_compat_golden/.dockerignore
@@ -1,0 +1,19 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.dockerignore
+Dockerfile
+.git
+.hg
+.svn

--- a/scripts/testdata/hello_world_compat_golden/.dockerignore
+++ b/scripts/testdata/hello_world_compat_golden/.dockerignore
@@ -1,17 +1,3 @@
-# Copyright 2015 Google Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 .dockerignore
 Dockerfile
 .git

--- a/scripts/testdata/hello_world_compat_golden/Dockerfile
+++ b/scripts/testdata/hello_world_compat_golden/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/google_appengine/python-compat-multicore
+ADD . /app/
+RUN if [ -s requirements.txt ]; then pip install -r requirements.txt; fi


### PR DESCRIPTION
Add support for python-compat.

This primarily side-steps the logic for python Dockerfile generation, as the compat Dockerfile is static and unchanging.