### PR TITLE
Skip test_xmlrpc_net when building python interpreters

### DIFF
--- a/python-interpreter-builder/scripts/build-python-3.5.sh
+++ b/python-interpreter-builder/scripts/build-python-3.5.sh
@@ -123,7 +123,8 @@ make profile-opt
 # test_dbm: https://bugs.python.org/issue28700
 # test_imap: https://bugs.python.org/issue30175
 # test_shutil: https://bugs.python.org/issue29317
-make test TESTOPTS="--exclude test___all__ test_dbm test_imaplib test_shutil"
+# test_xmlrpc_net: https://bugs.python.org/issue31724
+make test TESTOPTS="--exclude test___all__ test_dbm test_imaplib test_shutil test_xmlrpc_net"
 
 # Install
 make altinstall

--- a/python-interpreter-builder/scripts/build-python-3.6.sh
+++ b/python-interpreter-builder/scripts/build-python-3.6.sh
@@ -123,7 +123,8 @@ make profile-opt
 # test_dbm: https://bugs.python.org/issue28700
 # test_imap: https://bugs.python.org/issue30175
 # test_shutil: https://bugs.python.org/issue29317
-make test TESTOPTS="--exclude test___all__ test_dbm test_imaplib test_shutil"
+# test_xmlrpc_net: https://bugs.python.org/issue31724
+make test TESTOPTS="--exclude test___all__ test_dbm test_imaplib test_shutil test_xmlrpc_net"
 
 # Install
 make altinstall


### PR DESCRIPTION
Building python interpreter failed at test_xmlrpc_net, error message as below:
```
ERROR: test_python_builders (test.test_xmlrpc_net.PythonBuildersTest)
Step #0: ----------------------------------------------------------------------
Step #0: Traceback (most recent call last):
Step #0:   File "/opt/sources/Python-3.5.4/Lib/test/test_xmlrpc_net.py", line 17, in test_python_builders
Step #0:     builders = server.getAllBuilders()
Step #0:   File "/opt/sources/Python-3.5.4/Lib/xmlrpc/client.py", line 1092, in __call__
Step #0:     return self.__send(self.__name, args)
Step #0:   File "/opt/sources/Python-3.5.4/Lib/xmlrpc/client.py", line 1432, in __request
Step #0:     verbose=self.__verbose
Step #0:   File "/opt/sources/Python-3.5.4/Lib/xmlrpc/client.py", line 1134, in request
Step #0:     return self.single_request(host, handler, request_body, verbose)
Step #0:   File "/opt/sources/Python-3.5.4/Lib/xmlrpc/client.py", line 1167, in single_request
Step #0:     dict(resp.getheaders())
Step #0: xmlrpc.client.ProtocolError: <ProtocolError for buildbot.python.org/all/xmlrpc/: 503 Service Unavailable>
```
Skip `test_xmlrpc_net` for now, to unblock releasing the new Python runtime image to address CVE.