### PR TITLE
Add support for using Ubuntu 16 as a base instead of Debian 8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -148,11 +148,11 @@ if [ "${local}" -eq 1 ]; then
   gcloud_cmd="${local_gcloud_cmd}"
 fi
 
-# Use latest released Debian as our base image
+# Pick OS image to use as base
 if [ "${os_base}" == "ubuntu16" ]; then
-  export DEBIAN_BASE_IMAGE="gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+  export OS_BASE_IMAGE="gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
 else
-  export DEBIAN_BASE_IMAGE="gcr.io/google-appengine/debian8:latest"
+  export OS_BASE_IMAGE="gcr.io/google-appengine/debian8:latest"
 fi
 export STAGING_IMAGE="${DOCKER_NAMESPACE}/python:${TAG}"
 echo "Using base image name ${STAGING_IMAGE}"
@@ -168,7 +168,7 @@ for outfile in \
   tests/integration/Dockerfile \
   ; do
   envsubst <"${outfile}".in >"${outfile}" \
-    '$DEBIAN_BASE_IMAGE $STAGING_IMAGE $GOOGLE_CLOUD_PROJECT_FOR_TESTS $TAG'
+    '$OS_BASE_IMAGE $STAGING_IMAGE $GOOGLE_CLOUD_PROJECT_FOR_TESTS $TAG'
 done
 
 # Make some files available to the runtime builder Docker context

--- a/build.sh
+++ b/build.sh
@@ -24,9 +24,12 @@ test=0 # Should run standard test suite?
 
 local=0 # Should run using local Docker daemon instead of GCR?
 
+os_base=debian8 # Which operating system base to use
+
 # Note that $gcloud_cmd has spaces in it
-gcloud_cmd="gcloud beta container builds submit ."
-local_gcloud_cmd="scripts/local_cloudbuild.py"
+gcloud_cmd="gcloud container builds submit"
+# May need to install via "gcloud components install container-builder-local"
+local_gcloud_cmd="container-builder-local --push=false --dryrun=false"
 
 # Helper functions
 function fatal() {
@@ -44,6 +47,7 @@ Options:
   --[no]test: Run basic tests (default true if no options set)
   --[no]client_test: Run Google Cloud Client Library tests (default false)
   --[no]local: Build images using local Docker daemon (default false)
+  --os_base: Which OS image to build on top of [debian8, ubuntu16]
 "
 }
 
@@ -106,6 +110,14 @@ while [ $# -gt 0 ]; do
       local=0
       shift
       ;;
+    --os_base=debian8)
+      os_base=debian8
+      shift
+      ;;
+    --os_base=ubuntu16)
+      os_base=ubuntu16
+      shift
+      ;;
     --test)
       test=1
       shift
@@ -137,7 +149,11 @@ if [ "${local}" -eq 1 ]; then
 fi
 
 # Use latest released Debian as our base image
-export DEBIAN_BASE_IMAGE="gcr.io/google-appengine/debian8:latest"
+if [ "${os_base}" == "ubuntu16" ]; then
+  export DEBIAN_BASE_IMAGE="gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+else
+  export DEBIAN_BASE_IMAGE="gcr.io/google-appengine/debian8:latest"
+fi
 export STAGING_IMAGE="${DOCKER_NAMESPACE}/python:${TAG}"
 echo "Using base image name ${STAGING_IMAGE}"
 
@@ -171,23 +187,35 @@ cp -a scripts/testdata/hello_world/main.py tests/eventlet/main.py
 # Build images and push to GCR
 if [ "${build}" -eq 1 ]; then
   echo "Building images"
-  ${gcloud_cmd} --config cloudbuild.yaml --substitutions "${build_substitutions}"
+  ${gcloud_cmd} \
+    --config=cloudbuild.yaml \
+    --substitutions="${build_substitutions}" \
+    .
 fi
 
 # Run the tests that don't require (too many) external services
 if [ "${test}" -eq 1 ]; then
   echo "Testing compatibility with popular Python libraries"
-  ${gcloud_cmd} --config cloudbuild_test.yaml --substitutions "${substitutions}"
+  ${gcloud_cmd} \
+    --config=cloudbuild_test.yaml \
+    --substitutions="${substitutions}" \
+    .
 fi
 
 # Run client library tests
 if [ "${client_test}" -eq 1 ]; then
   echo "Testing compatibility with Google Cloud Client Libraries"
-  ${gcloud_cmd} --config cloudbuild_client_test.yaml --substitutions "${substitutions}"
+  ${gcloud_cmd} \
+    --config=cloudbuild_client_test.yaml \
+    --substitutions="${substitutions}" \
+    .
 fi
 
 # Run benchmarks
 if [ "${benchmark}" -eq 1 ] ; then
   echo "Running benchmark"
-  ${gcloud_cmd} --config cloudbuild_benchmark.yaml --substitutions  "${substitutions}"
+  ${gcloud_cmd} \
+    --config=cloudbuild_benchmark.yaml \
+    --substitutions="${substitutions}" \
+    .
 fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -41,7 +41,7 @@ steps:
     ]
 - name: gcr.io/cloud-builders/docker:latest
   args: [
-    'build', '-t', 'python3-libraries-intermediate', '--build-arg', 
+    'build', '-t', 'python3-libraries-intermediate', '--build-arg',
     'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
     '/workspace/tests/python3-libraries'
     ]

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -1,27 +1,12 @@
 timeout: 3600s
 steps:
- # Validate structure of base runtime image
-- name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '-t', 'python2-libraries-intermediate', '--build-arg', 
-         'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
-         '/workspace/tests/python2-libraries']
-- name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
+- # Explicitly pull image into GCB so that later steps work
+  name: '${_DOCKER_NAMESPACE}/python:${_TAG}'
   args: [
-    '-test.v',
-    '-image', 'python2-libraries-intermediate',
-    '/workspace/tests/python2-libraries/python2-libraries.yaml'
-  ]
-- name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '-t', 'python3-libraries-intermediate', '--build-arg', 
-         'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
-         '/workspace/tests/python3-libraries']
-- name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
-  args: [
-    '-test.v',
-    '-image', 'python3-libraries-intermediate',
-    '/workspace/tests/python3-libraries/python3-libraries.yaml'
-  ]
-- name: gcr.io/gcp-runtimes/container-structure-test:v0.1.1
+    '/bin/true',
+    ]
+- # Validate structure of base runtime image
+  name: gcr.io/gcp-runtimes/container-structure-test:v0.2.1
   args: [
     '-test.v',
     '-image', '${_DOCKER_NAMESPACE}/python:${_TAG}',
@@ -31,10 +16,45 @@ steps:
     '/workspace/tests/virtualenv/virtualenv_python35.yaml',
     '/workspace/tests/virtualenv/virtualenv_python36.yaml',
     '/workspace/tests/no-virtualenv/no-virtualenv.yaml',
-    '/workspace/tests/license-test/license-test.yaml'
     ]
-- # Run compatibility tests
+# Temporarily disabled because it fails on symbolic links in Ubuntu:
+#   https://github.com/GoogleCloudPlatform/container-structure-test/issues/77
+#- # Check license compliance
+#  name: gcr.io/gcp-runtimes/container-structure-test:v0.2.1
+#  args: [
+#    '-test.v',
+#    '-image', '${_DOCKER_NAMESPACE}/python:${_TAG}',
+#    '/workspace/tests/license-test/license-test.yaml'
+#    ]
+- # Do third-party library compatibility tests
   name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=${_DOCKER_NAMESPACE}/python/tests/eventlet:${_TAG}',
-         '--no-cache', '/workspace/tests/eventlet/']
+  args: [
+    'build', '-t', 'python2-libraries-intermediate', '--build-arg',
+    'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
+    '/workspace/tests/python2-libraries'
+    ]
+- name: gcr.io/gcp-runtimes/container-structure-test:v0.2.1
+  args: [
+    '-test.v',
+    '-image', 'python2-libraries-intermediate',
+    '/workspace/tests/python2-libraries/python2-libraries.yaml'
+    ]
+- name: gcr.io/cloud-builders/docker:latest
+  args: [
+    'build', '-t', 'python3-libraries-intermediate', '--build-arg', 
+    'intermediate_image=${_DOCKER_NAMESPACE}/python:${_TAG}',
+    '/workspace/tests/python3-libraries'
+    ]
+- name: gcr.io/gcp-runtimes/container-structure-test:v0.2.1
+  args: [
+    '-test.v',
+    '-image', 'python3-libraries-intermediate',
+    '/workspace/tests/python3-libraries/python3-libraries.yaml'
+    ]
+- # Run other compatibility tests
+  name: gcr.io/cloud-builders/docker:latest
+  args: [
+    'build', '--tag=${_DOCKER_NAMESPACE}/python/tests/eventlet:${_TAG}',
+    '--no-cache', '/workspace/tests/eventlet/'
+    ]
 images: []

--- a/python-interpreter-builder/Dockerfile.in
+++ b/python-interpreter-builder/Dockerfile.in
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -yq \
     mime-support \
     net-tools \
     netbase \
+    python \
+    python3 \
     sharutils \
     time \
     tk-dev \

--- a/python-interpreter-builder/Dockerfile.in
+++ b/python-interpreter-builder/Dockerfile.in
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get install -yq \
     mime-support \
     net-tools \
     netbase \
-    python3 \
     sharutils \
     time \
     tk-dev \
@@ -49,6 +48,8 @@ ADD DEBIAN /DEBIAN
 # Build the Python interpreters
 RUN mkdir -p /opt/packages && \
     echo -n "" > /opt/packages/packages.txt
+
+RUN /scripts/build-python-3.4.sh
 
 RUN /scripts/build-python-3.5.sh
 

--- a/python-interpreter-builder/Dockerfile.in
+++ b/python-interpreter-builder/Dockerfile.in
@@ -1,6 +1,6 @@
 # The Google App Engine base image is debian (jessie) with ca-certificates
 # installed.
-FROM ${DEBIAN_BASE_IMAGE}
+FROM ${OS_BASE_IMAGE}
 
 # Install Python build dependencies (based on Debian Build-Depends)
 RUN apt-get update && apt-get install -yq \

--- a/python-interpreter-builder/scripts/build-python-3.4.sh
+++ b/python-interpreter-builder/scripts/build-python-3.4.sh
@@ -37,9 +37,6 @@ cd Python-3.4.8
 #   (Debian) Ensure support is compiled in instead of relying on autodetection
 # --enable-loadable-sqlite-extensions
 #   (Debian)
-# --enable-optimizations
-#   Performance optimization (Enables PGO and may or may not enable
-#   LTO based on complex logic and bugs)
 # --prefix
 #   Avoid possible collisions with Debian or others
 # --with-computed-gotos
@@ -75,15 +72,6 @@ cd Python-3.4.8
 #   (Debian) Security hardening
 # RANLIB=
 #   (Debian) No-op
-#
-#
-# LTO (Link time optimization)
-#
-# Currently disabled, due to unresolved compile problems.  There is a
-# --with-lto flag, but Debian doesn't use it.  Instead, they pass lto
-# related flags in EXTRA_CFLAGS (to make, rather than configure).
-# Specifically EXTRA_CFLAGS="-g -flto -fuse-linker-plugin
-# -ffat-lto-objects"
 
 PREFIX=/opt/python3.4
 

--- a/python-interpreter-builder/scripts/build-python-3.4.sh
+++ b/python-interpreter-builder/scripts/build-python-3.4.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+# Get the source
+mkdir -p /opt/sources
+cd /opt/sources
+wget --no-verbose https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tgz
+# SHA-256 generated via `shasum -a 256 [file]`
+shasum --check <<EOF
+8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639  Python-3.4.8.tgz
+EOF
+tar xzf Python-3.4.8.tgz
+
+cd Python-3.4.8
+
+# Explanation of flags:
+#
+# Noteworthy Debian options we _don't_ use:
+#
+# --enable-shared
+#   This is complicated to get right, and we don't expect our
+#   customers to embed Python in a native code application.  There is
+#   also a noteworthy interaction with 'make altinstall'
+#   (https://bugs.python.org/issue27685)
+# --without-ensurepip
+#   Debian unbundles pip for their own reasons
+# CFLAGS=-fdebug-prefix-map
+#   Unnecessary in our build environment
+#
+#
+# Flags that we _do_ use:
+# (Debian) means it was taken from Debian build rules.
+#
+# --enable-ipv6
+#   (Debian) Ensure support is compiled in instead of relying on autodetection
+# --enable-loadable-sqlite-extensions
+#   (Debian)
+# --enable-optimizations
+#   Performance optimization (Enables PGO and may or may not enable
+#   LTO based on complex logic and bugs)
+# --prefix
+#   Avoid possible collisions with Debian or others
+# --with-computed-gotos
+#   (Debian) Performance optimization
+# --with-dbmliborder=bdb:gdbm
+#   (Debian) Python default is "ndbm:gdbm:bdb", I have no idea why one
+#   would prefer one over the other.
+# --with-fpectl
+#   (Debian) Floating point exception control
+# --with-system-expat
+#   (Debian) for compatibility with other Debian packages
+# --with-system-ffi
+#   (Debian) for compatibility with other Debian packages
+# --with-system-libmpdec
+#   (Debian) for compatibility with other Debian packages
+# AR=
+#   (Debian) No-op
+# CC=
+#   (Debian) No-op
+# CFLAGS=-fstack-protector-strong
+#   (Debian) Security hardening
+# CFLAGS=-g
+#   (Debian) More debug info
+# CFLAGS=-Wformat -Werror=format-security
+#   (Debian) Security hardening
+# CPPFLAGS=-D_FORTIFY_SOURCE=2
+#   (Debian) Security hardening
+# CPPFLAGS=-Wdate-time
+#   (Debian) Warnings about non-reproducible builds
+# CXX=
+#   (Debian) No-op
+# LDFLAGS=-Wl,-z,relro:
+#   (Debian) Security hardening
+# RANLIB=
+#   (Debian) No-op
+#
+#
+# LTO (Link time optimization)
+#
+# Currently disabled, due to unresolved compile problems.  There is a
+# --with-lto flag, but Debian doesn't use it.  Instead, they pass lto
+# related flags in EXTRA_CFLAGS (to make, rather than configure).
+# Specifically EXTRA_CFLAGS="-g -flto -fuse-linker-plugin
+# -ffat-lto-objects"
+
+PREFIX=/opt/python3.4
+
+mkdir build-static
+cd build-static
+
+../configure \
+  --enable-ipv6 \
+  --enable-loadable-sqlite-extensions \
+  --prefix="$PREFIX" \
+  --with-dbmliborder=bdb:gdbm \
+  --with-computed-gotos \
+  --with-fpectl \
+  --with-system-expat \
+  --with-system-ffi \
+  --with-system-libmpdec \
+  AR="x86_64-linux-gnu-gcc-ar" \
+  CC="x86_64-linux-gnu-gcc" \
+  CFLAGS="\
+    -fstack-protector-strong \
+    -g \
+    -Wformat -Werror=format-security \
+  " \
+  CPPFLAGS="\
+    -D_FORTIFY_SOURCE=2 \
+    -Wdate-time \
+  " \
+  CXX="x86_64-linux-gnu-g++" \
+  LDFLAGS="-Wl,-z,relro" \
+  RANLIB="x86_64-linux-gnu-gcc-ranlib" \
+
+make all
+
+# Run tests
+# test___all__: Depends on Debian-specific locale changes
+# test_dbm: https://bugs.python.org/issue28700
+# test_imap: https://bugs.python.org/issue30175
+# test_shutil: https://bugs.python.org/issue29317
+# test_subprocess: https://bugs.python.org/issue6135
+# test_xmlrpc_net: https://bugs.python.org/issue31724
+make test TESTOPTS="-uall,-network,-urlfetch --exclude test___all__ test_dbm test_imaplib test_shutil test_subprocess test_xmlrpc_net"
+
+# Install
+make altinstall
+# Remove redundant copy of libpython
+rm "$PREFIX"/lib/libpython3.4m.a
+# Remove opt-mode bytecode
+find "$PREFIX"/lib/python3.4/ \
+  -name \*.opt-\?.pyc \
+  -exec rm {} \;
+# Remove all but a few files in the 'test' subdirectory
+find "$PREFIX"/lib/python3.4/test \
+  -mindepth 1 -maxdepth 1 \
+  \! -name support \
+  -a \! -name __init__.py \
+  -a \! -name pystone.\* \
+  -a \! -name regrtest.\* \
+  -a \! -name test_support.py \
+  -exec rm -rf {} \;
+
+# Clean-up sources
+cd /opt
+rm /opt/sources/Python-3.4.8.tgz
+rm -r /opt/sources/Python-3.4.8

--- a/runtime-image/Dockerfile.in
+++ b/runtime-image/Dockerfile.in
@@ -20,12 +20,12 @@ ENV PYTHONUNBUFFERED 1
 ADD interpreters.tar.gz /
 
 # Add Google-built interpreters to the path
-ENV PATH /opt/python3.6/bin:/opt/python3.5/bin:$PATH
+ENV PATH /opt/python3.6/bin:/opt/python3.5/bin:/opt/python3.4/bin:$PATH
 
 # Upgrade pip (debian package version tends to run a few version behind) and
 # install virtualenv system-wide.
 RUN /usr/bin/pip install --upgrade -r /resources/requirements.txt && \
-    /usr/bin/pip3 install --upgrade -r /resources/requirements.txt && \
+    /opt/python3.4/bin/pip3.4 install --upgrade -r /resources/requirements.txt && \
     /opt/python3.5/bin/pip3.5 install --upgrade -r /resources/requirements.txt && \
     /opt/python3.6/bin/pip3.6 install --upgrade -r /resources/requirements.txt && \
     /usr/bin/pip install --upgrade -r /resources/requirements-virtualenv.txt

--- a/runtime-image/Dockerfile.in
+++ b/runtime-image/Dockerfile.in
@@ -1,7 +1,7 @@
 # The Google App Engine base image is debian (jessie) with ca-certificates
 # installed.
 # Source: https://github.com/GoogleCloudPlatform/debian-docker
-FROM ${DEBIAN_BASE_IMAGE}
+FROM ${OS_BASE_IMAGE}
 
 ADD resources /resources
 ADD scripts /scripts

--- a/runtime-image/resources/apt-packages.txt
+++ b/runtime-image/resources/apt-packages.txt
@@ -7,9 +7,6 @@ wget
 python-pip
 python2.7
 python2.7-dev
-python3-pip
-python3.4
-python3.4-dev
 # Dependenies for third-party Python packages
 # with C-extensions
 build-essential

--- a/tests/license-test/license-test.yaml
+++ b/tests/license-test/license-test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: "1.0.0"
 
-# See https://github.com/GoogleCloudPlatform/runtimes-common/blob/master/structure_tests/README.md#license-tests
+# See https://github.com/GoogleCloudPlatform/container-structure-test/blob/master/README.md
 licenseTests:
   - debian: true
     files: []

--- a/tests/no-virtualenv/no-virtualenv.yaml
+++ b/tests/no-virtualenv/no-virtualenv.yaml
@@ -22,7 +22,7 @@ commandTests:
 
   - name: "default python3.4 installation"
     command: ["which", "python3.4"]
-    expectedOutput: ["/usr/bin/python3.4\n"]
+    expectedOutput: ["/opt/python3.4/bin/python3.4\n"]
 
   - name: "default python3.5 installation"
     command: ["which", "python3.5"]

--- a/tests/virtualenv/virtualenv_default.yaml
+++ b/tests/virtualenv/virtualenv_default.yaml
@@ -17,7 +17,7 @@ commandTests:
     command: ["python", "--version"]
     # we check stderr instead of stdout for Python versions < 3.4
     # https://bugs.python.org/issue18338
-    expectedError: ["Python 2.7.9\n"]
+    expectedError: ["Python 2.7.(9|12)\n"]
 
   - name: "virtualenv pip installation"
     setup: [["virtualenv", "/env"]]

--- a/tests/virtualenv/virtualenv_python27.yaml
+++ b/tests/virtualenv/virtualenv_python27.yaml
@@ -27,7 +27,7 @@ commandTests:
     command: ["python", "--version"]
     # we check stderr instead of stdout for Python versions < 3.4
     # https://bugs.python.org/issue18338
-    expectedError: ["Python 2.7.9\n"]
+    expectedError: ["Python 2.7.(9|12)\n"]
 
   - name: "virtualenv27 pip installation"
     setup: [["virtualenv", "-p", "python", "/env"]]

--- a/tests/virtualenv/virtualenv_python34.yaml
+++ b/tests/virtualenv/virtualenv_python34.yaml
@@ -25,7 +25,7 @@ commandTests:
   - name: "virtualenv34 python version"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]
     command: ["python", "--version"]
-    expectedOutput: ["Python 3.4.2\n"]
+    expectedOutput: ["Python 3.4.8\n"]
 
   - name: "virtualenv34 pip installation"
     setup: [["virtualenv", "-p", "python3.4", "/env"]]


### PR DESCRIPTION
This requires building Python 3.4 from source, so we do that.

Future changes may add support for other OS base images, such as Debian 9 and Ubuntu 18.  We don't support arbitrary OS base images in general, so it's an enumerated list.
