### PR TITLE
Restore python3 and pip3 $PATH entries.

### DIFF
--- a/runtime-image/Dockerfile.in
+++ b/runtime-image/Dockerfile.in
@@ -21,6 +21,8 @@ ADD interpreters.tar.gz /
 
 # Add Google-built interpreters to the path
 ENV PATH /opt/python3.6/bin:/opt/python3.5/bin:/opt/python3.4/bin:$PATH
+RUN update-alternatives --install /usr/local/bin/python3 python3 /opt/python3.6/bin/python3.6 50
+RUN update-alternatives --install /usr/local/bin/pip3 pip3 /opt/python3.6/bin/pip3.6 50
 
 # Upgrade pip (debian package version tends to run a few version behind) and
 # install virtualenv system-wide.

--- a/tests/no-virtualenv/no-virtualenv.yaml
+++ b/tests/no-virtualenv/no-virtualenv.yaml
@@ -37,6 +37,17 @@ commandTests:
     command: ["which", "gunicorn"]
     expectedOutput: ["/usr/local/bin/gunicorn\n"]
 
+  - # Regression test for issue187
+    name: "default python3 installation"
+    command: ["which", "python3"]
+    expectedOutput: ["/usr/local/bin/python3\n"]
+  - name: "default python3 version"
+    command: ["python3", "--version"]
+    expectedOutput: ["Python 3.6.4\n"]
+  - name: "default pip3 installation"
+    command: ["which", "pip3"]
+    expectedOutput: ["/usr/local/bin/pip3\n"]
+
   - name: "default flask installation"
     # Checks that 'pip' and 'python' are using the same Python version
     setup: [["pip", "install", "flask"]]


### PR DESCRIPTION
They now invoke Python 3.6.  Previously they invoked Python 3.4.

Fixes #187 