### PR TITLE
Split the runtime release into an interpreter and a runtime build.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,6 +39,17 @@ follows:
 4. `build.sh` invokes Google Container Builder with the `cloudbuild-*.yaml`
    config files.
 
+## Building interpreters
+
+The interpreters used are now built in a separate step, and stored on GCS.
+This allows the runtime images to be build more rapidly.
+
+To build the interpreters, run:
+
+```shell
+gcloud container builds submit . --config=cloudbuild_interpreters.yaml
+```
+
 ## Building outside Jenkins
 
 To build this repository outside Jenkins, authenticate and authorize yourself

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ test=0 # Should run standard test suite?
 local=0 # Should run using local Docker daemon instead of GCR?
 
 os_base=debian8 # Which operating system base to use
+interpreter=0 # Should build interpreters instead of images
 
 # Note that $gcloud_cmd has spaces in it
 gcloud_cmd="gcloud container builds submit"
@@ -126,6 +127,10 @@ while [ $# -gt 0 ]; do
       test=0
       shift
       ;;
+    --interpreter)
+      interpreter=1
+      shift
+      ;;
     *)
       usage
       ;;
@@ -183,6 +188,14 @@ done
 
 # Make a file available to the eventlet test.
 cp -a scripts/testdata/hello_world/main.py tests/eventlet/main.py
+
+# Build interpreters and push to GCS
+if [ "${interpreter}" -eq 1 ]; then
+  echo "Building interpreters"
+  ${gcloud_cmd} \
+    --config=cloudbuild_interpreters.yaml \
+    .
+fi
 
 # Build images and push to GCR
 if [ "${build}" -eq 1 ]; then

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,29 +1,10 @@
 timeout: 10800s
 steps:
-- # Compile Python interpreters from source.  This step happens first, then
-  # the next three in parallel.
-  name: gcr.io/cloud-builders/docker:latest
-  args: ['build', '--tag=${_DOCKER_NAMESPACE}/python/interpreter-builder:${_TAG}',
-         '--no-cache', '/workspace/python-interpreter-builder/']
-  id: interpreter-builder
-- name: ${_DOCKER_NAMESPACE}/python/interpreter-builder:${_TAG}
-  args: ['/scripts/build-python-3.4.sh']
-  id: build-3.4
-  waitFor: ['interpreter-builder']
-- name: ${_DOCKER_NAMESPACE}/python/interpreter-builder:${_TAG}
-  args: ['/scripts/build-python-3.5.sh']
-  id: build-3.5
-  waitFor: ['interpreter-builder']
-- name: ${_DOCKER_NAMESPACE}/python/interpreter-builder:${_TAG}
-  args: ['/scripts/build-python-3.6.sh']
-  id: build-3.6
-  waitFor: ['interpreter-builder']
 - # Build base runtime image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', '--tag=${_DOCKER_NAMESPACE}/python:${_TAG}',
          '--no-cache', '/workspace/runtime-image/']
   id: runtime
-  waitFor: ['build-3.4', 'build-3.5', 'build-3.6']
 - # Build runtime builder image
   name: gcr.io/cloud-builders/docker:latest
   args: ['build', '--tag=${_BUILDER_DOCKER_NAMESPACE}/python/gen-dockerfile:${_TAG}',
@@ -31,7 +12,6 @@ steps:
   id: gen-dockerfile
   waitFor: ['runtime']
 images: [
-  '${_DOCKER_NAMESPACE}/python/interpreter-builder:${_TAG}',
   '${_DOCKER_NAMESPACE}/python:${_TAG}',
   '${_BUILDER_DOCKER_NAMESPACE}/python/gen-dockerfile:${_TAG}',
 ]

--- a/cloudbuild_interpreters.yaml
+++ b/cloudbuild_interpreters.yaml
@@ -1,0 +1,29 @@
+timeout: 10800s
+steps:
+- # Compile Python interpreters from source.  This step happens first, then
+  # the next three in parallel.
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', '--tag=interpreter-builder',
+         '--no-cache', '/workspace/python-interpreter-builder/']
+  id: interpreter-builder
+- name: interpreter-builder
+  args: ['/scripts/build-python-3.4.sh']
+  id: build-3.4
+  waitFor: ['interpreter-builder']
+- name: interpreter-builder
+  args: ['/scripts/build-python-3.5.sh']
+  id: build-3.5
+  waitFor: ['interpreter-builder']
+- name: interpreter-builder
+  args: ['/scripts/build-python-3.6.sh']
+  id: build-3.6
+  waitFor: ['interpreter-builder']
+
+# Upload them to tbe build-id location
+- name: gcr.io/cloud-builders/gsutil:latest
+  args: ['cp', '/workspace/runtime-image/*.tar.gz', 'gs://python-interpreters/$BUILD_ID/']
+  waitFor: ['build-3.4', 'build-3.5', 'build-3.6']
+
+# "Tag" this as latest
+- name: gcr.io/cloud-builders/gsutil:latest
+  args: ['cp', '-r', 'gs://python-interpreters/$BUILD_ID/*', 'gs://python-interpreters/latest/']

--- a/runtime-image/Dockerfile.in
+++ b/runtime-image/Dockerfile.in
@@ -16,10 +16,13 @@ ENV LANG C.UTF-8
 # logging collection.
 ENV PYTHONUNBUFFERED 1
 
-# Install the Google-built interpreters
-ADD interpreter-3.4.tar.gz /
-ADD interpreter-3.5.tar.gz /
-ADD interpreter-3.6.tar.gz /
+RUN wget https://storage.googleapis.com/python-interpreters/latest/interpreter-3.4.tar.gz && \
+    wget https://storage.googleapis.com/python-interpreters/latest/interpreter-3.5.tar.gz && \
+    wget https://storage.googleapis.com/python-interpreters/latest/interpreter-3.6.tar.gz && \
+    tar -xzf interpreter-3.4.tar.gz && \
+    tar -xzf interpreter-3.5.tar.gz && \
+    tar -xzf interpreter-3.6.tar.gz && \
+    rm interpreter-*.tar.gz
 
 # Add Google-built interpreters to the path
 ENV PATH /opt/python3.6/bin:/opt/python3.5/bin:/opt/python3.4/bin:$PATH


### PR DESCRIPTION
This makes it much faster to build runtime images.