### PR TITLE
Use kaniko for building

### DIFF
--- a/builder/python-latest.yaml
+++ b/builder/python-latest.yaml
@@ -6,5 +6,5 @@ steps:
     '--base-image=gcr.io/google-appengine/python:latest'
   ]
 # Use that Dockerfile to create final application image
-- name: 'gcr.io/kaniko-project/executor@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+- name: 'gcr.io/kaniko-project/executor:v0.4.0'
   args: ['--destination=$_OUTPUT_IMAGE']

--- a/builder/python-latest.yaml
+++ b/builder/python-latest.yaml
@@ -5,8 +5,6 @@ steps:
   args: [
     '--base-image=gcr.io/google-appengine/python:latest'
   ]
-- # Use that Dockerfile to create final application image
-  name: 'gcr.io/cloud-builders/docker:latest'
-  args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
-images:
- - '$_OUTPUT_IMAGE' 
+# Use that Dockerfile to create final application image
+- name: 'gcr.io/kaniko-project/executor@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+  args: ['--destination=$_OUTPUT_IMAGE']

--- a/builder/python-staging.yaml
+++ b/builder/python-staging.yaml
@@ -5,8 +5,6 @@ steps:
   args: [
     '--base-image=gcr.io/google-appengine/python:staging'
   ]
-- # Use that Dockerfile to create final application image
-  name: 'gcr.io/cloud-builders/docker:latest'
-  args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
-images:
- - '$_OUTPUT_IMAGE' 
+# Use that Dockerfile to create final application image
+- name: 'gcr.io/kaniko-project/executor@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+  args: ['--destination=$_OUTPUT_IMAGE']

--- a/builder/python-staging.yaml
+++ b/builder/python-staging.yaml
@@ -6,5 +6,5 @@ steps:
     '--base-image=gcr.io/google-appengine/python:staging'
   ]
 # Use that Dockerfile to create final application image
-- name: 'gcr.io/kaniko-project/executor@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+- name: 'gcr.io/kaniko-project/executor:v0.4.0'
   args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
kaniko builds container images from a Dockerfile, and enables future improvements to speed up builds by using the image registry as a layer cache (GoogleContainerTools/kaniko#300)