### PR TITLE
Document how to use Dockerfile with python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ command or entrypoint. For example:
     
     # Create a virtualenv for dependencies. This isolates these packages from
     # system-level packages.
+    # Use -p python3 or -p python3.7 to select python version. Default is version 2.
     RUN virtualenv /env
     
     # Setting these environment variables are the same as running


### PR DESCRIPTION
I had to dig around in `scripts/gen_dockerfile.py` and `scripts/data/Dockerfile.virtualenv.template` to figure this out after copy-pasting from the README.

It's sort of strange that the default is python2.7, but I wasn't sure if we wanted to change that in the sample.